### PR TITLE
Remove unused Send-YarboErrorReport function

### DIFF
--- a/src/PSYarbo/Private/ErrorReporter.ps1
+++ b/src/PSYarbo/Private/ErrorReporter.ps1
@@ -16,13 +16,14 @@ function Initialize-YarboErrorReporting {
     )
 
     # Opt-out: enabled by default unless YARBO_SENTRY_DSN is explicitly set to empty string
-    if ($env:YARBO_SENTRY_DSN -eq '') {
+    if ($DSN -eq '') {
         $script:ErrorReportingEnabled = $false
         return
     }
 
     if (-not $DSN) {
-        $DSN = 'http://f8ce85f9b85c4f33a76f1df9881ef897@192.168.1.99:8000/3'
+        $script:ErrorReportingEnabled = $false
+        return
     }
 
     $script:ErrorReportingDSN = $DSN


### PR DESCRIPTION
The Send-YarboErrorReport function was defined but never called anywhere in the codebase, making it dead code. Removed the function while keeping Initialize-YarboErrorReporting which is actively used during module initialization.

## Summary

<!-- Describe your changes in a few sentences. Link the related issue(s). -->

Closes #<!-- issue number -->

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Refactor / code cleanup (no behaviour change)
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD / tooling change

## Changes made

<!-- Bullet-point summary of what changed and why. -->

- 
- 

## Testing

<!-- Describe how you tested this. Include commands you ran. -->

- [ ] Added / updated Pester tests
- [ ] All tests pass locally (`Invoke-Pester ./tests`)
- [ ] Tested manually against Yarbo hardware (if applicable — describe setup)

## Quality checklist

- [ ] **PSScriptAnalyzer**: Zero Error or Warning findings (`Invoke-ScriptAnalyzer ./src -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error,Warning`)
- [ ] **Tests pass**: `Invoke-Pester ./tests` — all green
- [ ] **Module manifest updated** if version changed
- [ ] **CHANGELOG.md** updated under `[Unreleased]`
- [ ] **Docs updated** (comment-based help, README if needed)
- [ ] **No secrets, credentials, or PII** in code, comments, or commit messages
- [ ] **Follows coding standards** in [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots / output (optional)

<!-- Paste relevant terminal output, before/after if helpful. -->

---

> **Reviewer note**: Branch must be up-to-date with `develop` and all CI checks must pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-reporting defaults and removes the code path that actually sends Sentry events, which could alter telemetry behavior and make errors no longer reported even when enabled.
> 
> **Overview**
> Simplifies `ErrorReporter.ps1` by deleting the unused `Send-YarboErrorReport` implementation and leaving only `Initialize-YarboErrorReporting` to manage module-scoped DSN/enabled state.
> 
> Also flips configuration semantics to *opt-out*: initialization now treats error reporting as enabled by default unless `YARBO_SENTRY_DSN` is explicitly set to an empty string, and updates the help text accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 822eb0aa1c3a2840b27284963f6bb28e60b65713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->