### PR TITLE
Fix reused MQTT ClientId when connecting multiple robots via pipeline

### DIFF
--- a/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
@@ -88,18 +88,16 @@ function Connect-Yarbo {
         if (-not $Port) { $Port = $cfg['Port'] }
 
         # Generate unique ClientId per pipeline iteration if not provided
-        if (-not $ClientId) {
-            $ClientId = "PSYarbo-$([guid]::NewGuid().ToString('N').Substring(0,8))"
-        }
+        $effectiveClientId = if ($ClientId) { $ClientId } else { "PSYarbo-$([guid]::NewGuid().ToString('N').Substring(0,8))" }
 
         $conn = [YarboConnection]::new()
         $conn.Broker = $Broker
         $conn.Port = $Port
         $conn.SerialNumber = $SerialNumber
-        $conn.ClientId = $ClientId
+        $conn.ClientId = $effectiveClientId
         $conn.State = [MqttConnectionState]::Connecting
 
-        Write-Verbose (Protect-YarboLogMessage "[Connect-Yarbo] Connecting to ${Broker}:${Port} as $ClientId")
+        Write-Verbose (Protect-YarboLogMessage "[Connect-Yarbo] Connecting to ${Broker}:${Port} as $effectiveClientId")
 
         try {
             # Guard: MQTTnet assembly must be loaded before any connection attempt
@@ -117,7 +115,7 @@ function Connect-Yarbo {
 
             # Build connection options
             $optionsBuilder = $conn.MqttFactory.CreateClientOptionsBuilder()
-            $options = $optionsBuilder.WithTcpServer($Broker, $Port).WithClientId($ClientId).WithTimeout(
+            $options = $optionsBuilder.WithTcpServer($Broker, $Port).WithClientId($effectiveClientId).WithTimeout(
                 [TimeSpan]::FromSeconds($TimeoutSeconds)
             ).Build()
 


### PR DESCRIPTION
Use local variable  instead of reassigning  parameter to ensure unique ClientId generation for each pipeline iteration. This prevents MQTT broker from disconnecting previous connections when multiple robots are piped through Connect-Yarbo.

## Summary

<!-- Describe your changes in a few sentences. Link the related issue(s). -->

Closes #<!-- issue number -->

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Refactor / code cleanup (no behaviour change)
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD / tooling change

## Changes made

<!-- Bullet-point summary of what changed and why. -->

- 
- 

## Testing

<!-- Describe how you tested this. Include commands you ran. -->

- [ ] Added / updated Pester tests
- [ ] All tests pass locally (`Invoke-Pester ./tests`)
- [ ] Tested manually against Yarbo hardware (if applicable — describe setup)

## Quality checklist

- [ ] **PSScriptAnalyzer**: Zero Error or Warning findings (`Invoke-ScriptAnalyzer ./src -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error,Warning`)
- [ ] **Tests pass**: `Invoke-Pester ./tests` — all green
- [ ] **Module manifest updated** if version changed
- [ ] **CHANGELOG.md** updated under `[Unreleased]`
- [ ] **Docs updated** (comment-based help, README if needed)
- [ ] **No secrets, credentials, or PII** in code, comments, or commit messages
- [ ] **Follows coding standards** in [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots / output (optional)

<!-- Paste relevant terminal output, before/after if helpful. -->

---

> **Reviewer note**: Branch must be up-to-date with `develop` and all CI checks must pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to how `Connect-Yarbo` derives the MQTT `ClientId`; main risk is behavioral change for callers relying on parameter mutation/log output.
> 
> **Overview**
> Fixes `Connect-Yarbo` so that when `-ClientId` is omitted, a **new per-invocation** MQTT client ID is generated and used consistently without reassigning the `ClientId` parameter.
> 
> Connection setup now uses an `effectiveClientId` for `$conn.ClientId`, verbose logging, and `WithClientId(...)`, preventing client-ID reuse (and broker disconnects) when connecting to multiple robots via the pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 718a9e7df2d6ad3d51cf7b4c68ced6d4d7a38e06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->