### PR TITLE
Remove unused defaultBranch variable and unnecessary API call

### DIFF
--- a/.github/workflows/auto-create-pr.yml
+++ b/.github/workflows/auto-create-pr.yml
@@ -58,10 +58,6 @@ jobs:
               return;
             }
 
-            // Get default branch to target
-            const { data: repoInfo } = await github.rest.repos.get({ owner, repo });
-            const defaultBranch = repoInfo.default_branch;
-            
             // Format title from branch name (e.g. bugfix/autofix-test -> Bugfix/autofix test)
             let title = branch.split('/').pop().replace(/-/g, ' ');
             title = title.charAt(0).toUpperCase() + title.slice(1);


### PR DESCRIPTION
## Summary

<!-- Describe your changes in a few sentences. Link the related issue(s). -->

Closes #<!-- issue number -->

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Refactor / code cleanup (no behaviour change)
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD / tooling change

## Changes made

<!-- Bullet-point summary of what changed and why. -->

- 
- 

## Testing

<!-- Describe how you tested this. Include commands you ran. -->

- [ ] Added / updated Pester tests
- [ ] All tests pass locally (`Invoke-Pester ./tests`)
- [ ] Tested manually against Yarbo hardware (if applicable — describe setup)

## Quality checklist

- [ ] **PSScriptAnalyzer**: Zero Error or Warning findings (`Invoke-ScriptAnalyzer ./src -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error,Warning`)
- [ ] **Tests pass**: `Invoke-Pester ./tests` — all green
- [ ] **Module manifest updated** if version changed
- [ ] **CHANGELOG.md** updated under `[Unreleased]`
- [ ] **Docs updated** (comment-based help, README if needed)
- [ ] **No secrets, credentials, or PII** in code, comments, or commit messages
- [ ] **Follows coding standards** in [CONTRIBUTING.md](../CONTRIBUTING.md)

## Screenshots / output (optional)

<!-- Paste relevant terminal output, before/after if helpful. -->

---

> **Reviewer note**: Branch must be up-to-date with `develop` and all CI checks must pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup in GitHub Actions workflow; it removes an unnecessary GitHub API call without changing PR creation inputs (still targets `develop`).
> 
> **Overview**
> Removes the unused default-branch lookup (`repos.get`) from the `auto-create-pr` GitHub Actions workflow, avoiding an extra API call.
> 
> PR auto-creation behavior remains the same, continuing to create bot/agent PRs against `develop` with the existing title formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de32db437f3ed1b3a6d776e9a57d007d00b5a3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->