### PR TITLE
Discovery, display consistency, full MQTT mapping, integration tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -43,7 +43,7 @@ body:
       render: powershell
       placeholder: |
         # Example:
-        Connect-Yarbo -MowerSerial 'YB-XXXX' -MqttServer '192.168.1.100'
+        Connect-Yarbo -Broker '<rover-ip>' -SerialNumber '<serial-number>'
         Get-YarboStatus | Format-List
 
   - type: checkboxes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           Import-Module Pester -MinimumVersion 5.0.0 -Force
           $intConfig = New-PesterConfiguration
           $intConfig.Run.Path              = './tests/Integration'
-          $intConfig.Run.Exit              = $true
+          $intConfig.Run.Exit              = $false
           $intConfig.Filter.ExcludeTag     = 'Integration'
           $intConfig.Output.Verbosity      = 'Detailed'
           $intConfig.TestResult.Enabled    = $true
@@ -106,6 +106,13 @@ jobs:
           $intConfig.TestResult.OutputFormat = 'NUnitXml'
           # ErrorOnNoTests removed — not available in all Pester versions
           $intResult = Invoke-Pester -Configuration $intConfig
+          if ($intResult.TotalCount -eq 0) {
+            Write-Error "Integration test step ran 0 tests — check that mocked test files exist and are tagged 'Mocked'"
+            exit 1
+          }
+          if ($intResult.FailedCount -gt 0) {
+            exit 1
+          }
 
       - name: Run root tests (PSYarbo.Tests, PSScriptAnalyzer) and exit on failure
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           New-Item -ItemType Directory -Path 'output/test-results' -Force | Out-Null
           $unitConfig = New-PesterConfiguration
           $unitConfig.Run.Path              = './tests/Unit'
-          $unitConfig.Run.Exit              = $false
+          $unitConfig.Run.Exit              = $true
           $unitConfig.Run.ExitCode          = 'None'
           $unitConfig.Output.Verbosity      = 'Detailed'
           $unitConfig.Filter.ExcludeTag    = 'Integration'
@@ -98,7 +98,7 @@ jobs:
           Import-Module Pester -MinimumVersion 5.0.0 -Force
           $intConfig = New-PesterConfiguration
           $intConfig.Run.Path              = './tests/Integration'
-          $intConfig.Run.Exit              = $false
+          $intConfig.Run.Exit              = $true
           $intConfig.Run.ExitCode          = 'None'
           $intConfig.Filter.ExcludeTag     = 'Integration'
           $intConfig.Output.Verbosity      = 'Detailed'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           $intConfig = New-PesterConfiguration
           $intConfig.Run.Path              = './tests/Integration'
           $intConfig.Run.Exit              = $false
+          $intConfig.Run.PassThru          = $true
           $intConfig.Filter.ExcludeTag     = 'Integration'
           $intConfig.Output.Verbosity      = 'Detailed'
           $intConfig.TestResult.Enabled    = $true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,19 +72,54 @@ jobs:
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module -Name PSScriptAnalyzer -MinimumVersion 1.21.0 -Scope CurrentUser -Force
 
-      - name: Run Pester tests
+      - name: Install MQTTnet (for module load in tests)
+        shell: pwsh
+        run: ./build/Install-Dependencies.ps1
+
+      - name: Run Unit tests
         shell: pwsh
         run: |
           Import-Module Pester -MinimumVersion 5.0.0 -Force
-          $config = New-PesterConfiguration
-          $config.Run.Path              = './tests'
-          $config.Run.Exit              = $true
-          $config.Output.Verbosity      = 'Detailed'
-          $config.TestResult.Enabled    = $true
-          $config.TestResult.OutputPath = 'output/test-results/pester-${{ matrix.os }}.xml'
-          $config.TestResult.OutputFormat = 'NUnitXml'
           New-Item -ItemType Directory -Path 'output/test-results' -Force | Out-Null
-          Invoke-Pester -Configuration $config
+          $unitConfig = New-PesterConfiguration
+          $unitConfig.Run.Path              = './tests/Unit'
+          $unitConfig.Run.Exit              = $false
+          $unitConfig.Run.ExitCode          = 'None'
+          $unitConfig.Output.Verbosity      = 'Detailed'
+          $unitConfig.Filter.ExcludeTag    = 'Integration'
+          $unitConfig.TestResult.Enabled   = $true
+          $unitConfig.TestResult.OutputPath = 'output/test-results/pester-unit-${{ matrix.os }}.xml'
+          $unitConfig.TestResult.OutputFormat = 'NUnitXml'
+          $unitResult = Invoke-Pester -Configuration $unitConfig
+
+      - name: Run Integration tests (mocked; excludes real-robot Integration tag)
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
+          $intConfig = New-PesterConfiguration
+          $intConfig.Run.Path              = './tests/Integration'
+          $intConfig.Run.Exit              = $false
+          $intConfig.Run.ExitCode          = 'None'
+          $intConfig.Filter.ExcludeTag     = 'Integration'
+          $intConfig.Output.Verbosity      = 'Detailed'
+          $intConfig.TestResult.Enabled    = $true
+          $intConfig.TestResult.OutputPath = 'output/test-results/pester-integration-${{ matrix.os }}.xml'
+          $intConfig.TestResult.OutputFormat = 'NUnitXml'
+          $intResult = Invoke-Pester -Configuration $intConfig
+
+      - name: Run root tests (PSYarbo.Tests, PSScriptAnalyzer) and exit on failure
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
+          $rootConfig = New-PesterConfiguration
+          $rootConfig.Run.Path              = './tests/PSYarbo.Tests.ps1', './tests/PSScriptAnalyzer.Tests.ps1'
+          $rootConfig.Run.Exit              = $true
+          $rootConfig.Filter.ExcludeTag     = 'Integration'
+          $rootConfig.Output.Verbosity      = 'Detailed'
+          $rootConfig.TestResult.Enabled    = $true
+          $rootConfig.TestResult.OutputPath = 'output/test-results/pester-root-${{ matrix.os }}.xml'
+          $rootConfig.TestResult.OutputFormat = 'NUnitXml'
+          Invoke-Pester -Configuration $rootConfig
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           $intConfig.Run.Path              = './tests/Integration'
           $intConfig.Run.Exit              = $false
           $intConfig.Run.PassThru          = $true
-          $intConfig.Filter.ExcludeTag     = 'Integration'
+          $intConfig.Filter.Tag            = 'Mocked'
           $intConfig.Output.Verbosity      = 'Detailed'
           $intConfig.TestResult.Enabled    = $true
           $intConfig.TestResult.OutputPath = 'output/test-results/pester-integration-${{ matrix.os }}.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           $intConfig.TestResult.Enabled    = $true
           $intConfig.TestResult.OutputPath = 'output/test-results/pester-integration-${{ matrix.os }}.xml'
           $intConfig.TestResult.OutputFormat = 'NUnitXml'
+          $intConfig.Should.ErrorOnNoTests = $true
           $intResult = Invoke-Pester -Configuration $intConfig
 
       - name: Run root tests (PSYarbo.Tests, PSScriptAnalyzer) and exit on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           $intConfig.TestResult.Enabled    = $true
           $intConfig.TestResult.OutputPath = 'output/test-results/pester-integration-${{ matrix.os }}.xml'
           $intConfig.TestResult.OutputFormat = 'NUnitXml'
-          $intConfig.Should.ErrorOnNoTests = $true
+          # ErrorOnNoTests removed — not available in all Pester versions
           $intResult = Invoke-Pester -Configuration $intConfig
 
       - name: Run root tests (PSYarbo.Tests, PSScriptAnalyzer) and exit on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
           $unitConfig = New-PesterConfiguration
           $unitConfig.Run.Path              = './tests/Unit'
           $unitConfig.Run.Exit              = $true
-          $unitConfig.Run.ExitCode          = 'None'
           $unitConfig.Output.Verbosity      = 'Detailed'
           $unitConfig.Filter.ExcludeTag    = 'Integration'
           $unitConfig.TestResult.Enabled   = $true
@@ -99,7 +98,6 @@ jobs:
           $intConfig = New-PesterConfiguration
           $intConfig.Run.Path              = './tests/Integration'
           $intConfig.Run.Exit              = $true
-          $intConfig.Run.ExitCode          = 'None'
           $intConfig.Filter.ExcludeTag     = 'Integration'
           $intConfig.Output.Verbosity      = 'Detailed'
           $intConfig.TestResult.Enabled    = $true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,17 +114,21 @@ function Connect-Yarbo {
         Brief one-line description.
     .DESCRIPTION
         Longer description.
-    .PARAMETER MqttServer
-        MQTT broker hostname or IP.
+    .PARAMETER Broker
+        MQTT broker hostname or IP (use Find-YarboDevice to discover).
+    .PARAMETER SerialNumber
+        Robot serial number.
     .EXAMPLE
-        Connect-Yarbo -MqttServer '192.168.1.100'
+        Connect-Yarbo -Broker '<rover-ip>' -SerialNumber '<serial-number>'
     .NOTES
         Author: Your Name
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string] $MqttServer
+        [string] $Broker,
+        [Parameter(Mandatory)]
+        [string] $SerialNumber
     )
     # ...
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Write-Host "Found: $($robot.SerialNumber) at $($robot.Broker)"
 $conn = $robot | Connect-Yarbo
 
 # — OR — connect directly
-$conn = Connect-Yarbo -Broker 192.168.1.24 -SerialNumber 24400102L8HO5227
+$conn = Connect-Yarbo -Broker <rover-ip> -SerialNumber <serial-number>
 
 # Check status
 Get-YarboStatus
@@ -88,7 +88,7 @@ Disconnect-Yarbo
 
 | Cmdlet | Description |
 |--------|-------------|
-| `Find-Yarbo` | Auto-discover Yarbo robots via MQTT `heart_beat`. Returns `YarboRobot[]`. |
+| `Find-Yarbo` | Auto-discover Yarbo robots via MQTT (DeviceMSG, data_feedback, heart_beat; aligned with [python-yarbo](https://github.com/markus-lassfolk/python-yarbo)). Returns `YarboRobot[]`. |
 | `Connect-Yarbo` | Connect to a robot's MQTT broker. Returns `YarboConnection`. |
 | `Disconnect-Yarbo` | Disconnect and dispose resources. |
 | `Test-YarboConnection` | Test if a connection is alive. |
@@ -164,6 +164,8 @@ PSYarbo uses the `snowbot/{SN}/...` MQTT topic hierarchy discovered by reverse e
 👉 **[markus-lassfolk/yarbo-reversing](https://github.com/markus-lassfolk/yarbo-reversing)**
 
 See also: `Get-Help about_PSYarbo_MQTT`
+
+**Discovery:** Find-Yarbo and Find-YarboDevice use the same strategy as [python-yarbo](https://github.com/markus-lassfolk/python-yarbo): anonymous MQTT client, subscribe to `snowbot/+/device/DeviceMSG`, `snowbot/+/device/data_feedback`, and `snowbot/+/device/heart_beat`, and derive the robot serial number from the first message received. Default is 192.168.1.0/24 (typical home LAN); pass `-Subnet` if your network uses a different range so discovery can scan it. If discovery finds no robots, run from a host on the same LAN as the Yarbo and ensure the robot is powered and connected.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Disconnect-Yarbo
 
 ---
 
+## Commands and properties (how to get information)
+
+For detailed examples of **which cmdlets to use** and **which properties to read** (battery, RTK, LEDs, `SystemInfo.cpu.Temperature`, `LedInfo`, telemetry, etc.), see:
+
+📖 **[Commands and Properties](docs/Commands-and-Properties.md)** — status vs telemetry, property reference, and example snippets.
+
+---
+
 ## Cmdlet Reference
 
 ### Connection
@@ -154,6 +162,52 @@ Disconnect-Yarbo
 | `Get-YarboDevice` | List robots bound to your account. |
 | `Get-YarboVideo` | Get video token/URL. |
 | `Get-YarboPlanHistory` | Get plan execution history from cloud. |
+
+### Utility
+
+| Cmdlet | Description |
+|--------|-------------|
+| `Test-YarboConnection` | Test if a connection is alive. |
+| `Get-YarboLog` | View CommandLog and TelemetryLog (sent/received MQTT). |
+| `Get-YarboMqttRecordingReport` | Report topic coverage from an MQTT recording. |
+| `Export-YarboSupportBundle` | Export a redacted MQTT/connection bundle for support (e.g. GlitchTip). |
+
+---
+
+## Debug logging and support bundles
+
+To see what is being **sent and received** over MQTT (useful for troubleshooting firmware or unsupported heads/attachments), use either:
+
+- **`-Debug`** — Pass the common `-Debug` switch to any cmdlet that uses MQTT. Debug output shows topic, payload (human-readable JSON), and responses.
+- **Environment variable `PSYARBO_DEBUG`** — Set `$env:PSYARBO_DEBUG = "1"` (or `"true"`) so that debug output is shown for all MQTT traffic without passing `-Debug` every time. Output is written as information stream so it appears in the console.
+
+For **raw payloads** (base64 of the zlib-compressed bytes) instead of human-readable JSON, set **`PSYARBO_DEBUG_RAW=1`** (or `"true"`).
+
+```powershell
+# One-off debug for a single command
+Get-YarboStatus -Debug
+
+# Session-wide debug (no -Debug needed)
+$env:PSYARBO_DEBUG = "1"
+Get-YarboStatus
+Send-YarboCommand -Command read_global_params
+
+# Raw payload format
+$env:PSYARBO_DEBUG_RAW = "1"
+Get-YarboStatus -Debug
+```
+
+To provide a **full MQTT dump** for support (e.g. GlitchTip or when opening an issue), use **`Export-YarboSupportBundle`**. It produces a redacted JSON file from a recording and/or the current connection log. You can upload that file to your issue tracker.
+
+```powershell
+# From an MQTT recording (Invoke-YarboMqttSniff -RecordPath ...)
+Export-YarboSupportBundle -Path ./support-bundle.json -RecordingPath ./mqtt-recording.json
+
+# From the current connection (recent CommandLog + TelemetryLog)
+Export-YarboSupportBundle -Path ./support-bundle.json -Connection $conn
+```
+
+Full in-product documentation: `Get-Help about_PSYarbo_Debug`. This aligns with [python-yarbo #59 — Debug Logging](https://github.com/markus-lassfolk/python-yarbo/issues/59).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ PSYarbo uses the `snowbot/{SN}/...` MQTT topic hierarchy discovered by reverse e
 
 See also: `Get-Help about_PSYarbo_MQTT`
 
-**Discovery:** Find-Yarbo and Find-YarboDevice use the same strategy as [python-yarbo](https://github.com/markus-lassfolk/python-yarbo): anonymous MQTT client, subscribe to `snowbot/+/device/DeviceMSG`, `snowbot/+/device/data_feedback`, and `snowbot/+/device/heart_beat`, and derive the robot serial number from the first message received. Default is 192.168.1.0/24 (typical home LAN); pass `-Subnet` if your network uses a different range so discovery can scan it. If discovery finds no robots, run from a host on the same LAN as the Yarbo and ensure the robot is powered and connected.
+**Discovery:** Find-Yarbo and Find-YarboDevice use the same strategy as [python-yarbo](https://github.com/markus-lassfolk/python-yarbo): anonymous MQTT client, subscribe to `snowbot/+/device/DeviceMSG`, `snowbot/+/device/data_feedback`, and `snowbot/+/device/heart_beat`, and derive the robot serial number from the first message received. By default, discovery scans all networks this machine has an IP on; pass `-Subnet` (e.g. `192.0.2.0/24`) if you want to limit the scan. If discovery finds no robots, run from a host on the same LAN as the Yarbo and ensure the robot is powered and connected.
 
 ---
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -76,6 +76,8 @@ $lintFindings = @()
 foreach ($file in $psFiles) {
     $lintFindings += Invoke-ScriptAnalyzer -Path $file.FullName -Settings $settings -Severity Error, Warning
 }
+# Only fail on Error/Warning (exclude Information e.g. TypeNotFound in class files loaded via ScriptsToProcess)
+$lintFindings = @($lintFindings | Where-Object { $_.Severity -in 'Error', 'Warning' })
 
 if ($lintFindings.Count -gt 0) {
     $lintFindings | Format-Table -AutoSize

--- a/docs/Commands-and-Properties.md
+++ b/docs/Commands-and-Properties.md
@@ -1,0 +1,398 @@
+# Commands and Properties — Getting Information from Your Robot
+
+This guide shows which cmdlets to use and which properties to read for status, telemetry, battery, RTK, LEDs, system info, and more.
+
+---
+
+## Connect first
+
+```powershell
+# Discover and connect (recommended)
+$robot = Find-Yarbo | Select-Object -First 1
+$conn = $robot | Connect-Yarbo
+
+# Or connect directly if you know broker and serial number
+$conn = Connect-Yarbo -Broker 192.168.1.24 -SerialNumber 24400102L8HO5227
+```
+
+After connecting, `Get-YarboStatus` and `Get-YarboTelemetry` use the current default connection unless you pass `-Connection $conn`.
+
+---
+
+## Status vs telemetry
+
+| What you want | Cmdlet | Returns |
+|---------------|--------|--------|
+| **Full robot status** (one snapshot) | `Get-YarboStatus` or `Get-YarboRobot` | `YarboRobot` |
+| **Single telemetry snapshot** | `Get-YarboTelemetry` | `YarboTelemetry` |
+| **Streaming telemetry** | `Watch-YarboTelemetry -Duration 00:01:00` | Events (YarboTelemetry objects) |
+| **Battery only** | `Get-YarboBattery` | Integer 0–100 |
+
+`YarboRobot` and `YarboTelemetry` share most of the same properties (both are built from the same MQTT DeviceMSG). Use **Get-YarboStatus** when you want the full status object to inspect or script against.
+
+---
+
+## Getting status and storing it
+
+```powershell
+$status = Get-YarboStatus    # or: Get-YarboRobot
+# $status is a YarboRobot with many properties (see below)
+```
+
+---
+
+## Property reference
+
+### Identity
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `SerialNumber` | string | Robot serial number |
+| `HeadSerialNumber` | string | Attached head serial |
+| `Name` | string | Robot name (if set) — **from cloud only, not MQTT** |
+| `HeadType` | int | Head type identifier |
+
+**Robot name (the one you gave it):** Local MQTT does **not** provide the robot’s friendly name. That name comes from the **cloud API**. Use `Get-YarboDevice` (after `Connect-YarboCloud`) to get it; each device has a `.name` property (e.g. `"My Yarbo"`). You can match by `SerialNumber` and assign it to your status object if you want:
+
+```powershell
+Connect-YarboCloud -Email you@example.com -Password $pw
+$devices = Get-YarboDevice
+$status = Get-YarboStatus
+$status.Name = ($devices | Where-Object { $_.sn -eq $status.SerialNumber }).name
+# Now $status.Name is e.g. "My Yarbo"
+```
+
+**Example:** `$status.SerialNumber` → `24400102L8HO5227`
+
+---
+
+### Battery (BatteryMSG)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `BatteryCapacity` | int | Charge percentage (0–100) |
+| `BatteryStatus` | int | Status code |
+| `BatteryTempError` | bool | Temperature error flag |
+| `BatteryTimestamp` | double | Device timestamp |
+| `BatteryCurrent` | double | Current (when present) |
+| `BatteryVoltage` | double | Voltage (when present) |
+
+**Examples:**
+
+```powershell
+$status.BatteryCapacity      # e.g. 83
+$status.BatteryCurrent       # current draw
+$status.BatteryVoltage       # voltage
+Get-YarboBattery             # quick 0–100 only
+```
+
+---
+
+### State (StateMSG)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `WorkingState` | int | 0 = idle, non-zero = active |
+| `ChargingStatus` | int | Charging state |
+| `ErrorCode` | int | Error code (0 = none) |
+| `IsPlanning` | bool | Plan in progress |
+| `IsPaused` | bool | Plan paused |
+| `IsRecharging` | bool | Recharge in progress |
+| `CarController` | bool | Car controller flag |
+| `MachineController` | int | Machine controller state |
+| `AdjustAngleStatus` | int | Adjust angle state |
+| `AutoDrawWaitingState` | int | Auto-draw waiting state |
+| `EnStateLed` | int | State LED enable |
+| `EnWarnLed` | int | Warning LED enable |
+| `OnGoingToStartPoint` | bool | Going to start point |
+| `OnMulPoints` | bool | Multi-point state |
+| `RobotFollowState` | int | Follow state |
+| `ScheduleCancel` | int | Schedule cancel state |
+| `VisionAutoDrawState` | int | Vision auto-draw state |
+
+**Examples:**
+
+```powershell
+$status.WorkingState         # 0 = idle
+$status.IsPlanning           # true if plan running
+$status.ErrorCode            # 0 = no error
+```
+
+---
+
+### Position / navigation (RTK, odometry)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `OdometryX`, `OdometryY`, `OdometryPhi` | double | Odometry position |
+| `Heading` | double | Heading (degrees) |
+| `RtkHeadingStatus` | int | RTK heading status |
+| `RtkStatus` | string | RTK status string |
+| `RtkHeadingDop` | double | Heading DOP |
+| `OdomConfidence` | double | Odometry confidence |
+| `RtkGgaAtnDis` | double | GGA attenuation |
+| `RtkHeadingAtnDis` | double | Heading attenuation |
+| `RtkHeadingMulti` | int | Heading multi |
+| `RtkHeadingObs` | int | Heading observations |
+| `RtkPre4Timestamp` | double | Pre4 timestamp |
+| `RtkVersion` | string | RTK firmware version |
+| `RtkSatNum` | int | Number of satellites |
+| `RtkTimestamp` | double | RTK timestamp |
+| `RtcmAge` | double | RTCM age |
+| `RtcmInfo` | object | RTCM info (nested) |
+| `RoverHeading` | string | Rover heading from rtk_base_data |
+| `BaseGngga` | string | Base station GNGGA sentence |
+
+**Examples:**
+
+```powershell
+$status.Heading              # e.g. 339.45
+$status.RtkStatus            # e.g. "4"
+$status.RtkVersion           # RTK version string
+$status.RtkSatNum            # satellite count
+$tel = Get-YarboTelemetry
+$tel.RtkSatNum
+$tel.RoverHeading
+```
+
+---
+
+### Hardware (RunningStatusMSG, LED, wireless charge)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ChuteAngle` | int | Chute angle (snow blower) |
+| `RainSensorData` | int | Rain sensor value |
+| `ChuteSteeringEngineInfo` | int | Chute steering engine |
+| `ChuteSteeringRunStatus` | int | Chute run status |
+| `HeadGyroPitch` | double | Head gyro pitch |
+| `HeadGyroRoll` | double | Head gyro roll |
+| `PushPodStatus` | int | Push pod status |
+| `PushRodPlace` | int | Push rod place |
+| `SnowPipeRunStatus` | int | Snow pipe run status |
+| `SnowRollerMotor` | int | Snow roller motor |
+| `ElecNavigationFrontRightSensor` | int | Nav sensor front-right |
+| `ElecNavigationRearRightSensor` | int | Nav sensor rear-right |
+| `LedRegister` | string | Raw LED register value |
+| `LedInfo` | object | LED info (body_left_r/g/b, body_right_*, led_head, led_left_w, led_right_w, tail_left_r, tail_right_r) |
+| `HeadLedBrightness` | int | Head LED brightness |
+| `WirelessChargeState` | int | Wireless charge state |
+| `WirelessChargeVoltage` | double | Charge voltage |
+| `WirelessChargeCurrent` | double | Charge current |
+| `WirelessChargeErrorCode` | int | Charge error code |
+| `BrushlessMotorCurrent` | double | Brushless motor current (EletricMSG) |
+| `NtcTemperature` | double | NTC temperature |
+| `PushPodCurrent` | double | Push pod current |
+
+**Examples:**
+
+```powershell
+$status.ChuteAngle
+$status.LedInfo.led_head
+$status.LedInfo.body_left_r
+$status.HeadLedBrightness
+$tel = Get-YarboTelemetry
+$tel.ChuteSteeringRunStatus
+$tel.HeadGyroPitch
+```
+
+---
+
+### Ultrasonic sensors
+
+| Property | Type |
+|----------|------|
+| `UltrasonicLeftFront` | int |
+| `UltrasonicMiddle` | int |
+| `UltrasonicRightFront` | int |
+
+**Example:** `$status.UltrasonicLeftFront`
+
+---
+
+### Network and misc
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `RoutePriority` | hashtable | Route priority (e.g. hg0, wlan0, wwan0) |
+| `BaseStatus` | object | base_status payload |
+| `Bds`, `Bs`, `Ms`, `S`, `Sbs`, `Tms` | object | Misc MQTT fields (when present) |
+| `GreenGrassUpdateSwitch` | int | Green grass update switch |
+| `IpcameraOtaSwitch` | int | IPC camera OTA switch |
+| `SystemInfo` | object | system_info (cpu.Frequency, cpu.Temperature, cpu.Usage, mem.*, userdata.disk.*, topProc) |
+| `DebugMsg` | object | Debug message payload |
+| `DeviceTimestamp` | double | Device message timestamp |
+| `LastUpdated` | datetime | When we last updated this object |
+
+**Examples:**
+
+```powershell
+$status.SystemInfo.cpu.Temperature
+$status.SystemInfo.cpu.Usage
+$status.SystemInfo.mem.MemAvailable
+$status.SystemInfo.userdata.disk.availableSize
+$status.RoutePriority.wlan0
+```
+
+---
+
+### YarboTelemetry-only (position as X/Y/Phi)
+
+`Get-YarboTelemetry` returns a `YarboTelemetry` object. It has the same MQTT-derived properties as above, plus:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Timestamp` | datetime | When the snapshot was taken |
+| `X`, `Y`, `Phi` | double | Position (CombinedOdom) |
+| `Latitude`, `Longitude`, `Altitude` | double? | Parsed from GPS (rtk_base_data.rover.gngga) |
+| `FixQuality` | int | GPS fix quality |
+| `GnggaRaw` | string | Raw GNGGA NMEA sentence |
+
+**Example:**
+
+```powershell
+$tel = Get-YarboTelemetry
+$tel.X
+$tel.Latitude
+$tel.GnggaRaw
+```
+
+---
+
+## Full MQTT payload (RawMessage)
+
+Every property above is taken from the robot’s MQTT DeviceMSG. The **entire** decoded payload is also available so you can access any field that isn’t mapped to a typed property:
+
+```powershell
+$status = Get-YarboStatus
+$status.RawMessage           # full DeviceMSG PSCustomObject
+$status.RawMessage.SomeKey   # any key from the JSON
+```
+
+---
+
+## Example snippets
+
+```powershell
+# Connect and get status
+$robot = Find-Yarbo | Select-Object -First 1
+$robot | Connect-Yarbo | Out-Null
+$status = Get-YarboStatus
+
+# Battery and basic state
+$status.BatteryCapacity
+$status.BatteryCurrent
+$status.BatteryVoltage
+$status.WorkingState
+
+# RTK / GPS
+$status.RtkVersion
+$status.RtkSatNum
+$status.Heading
+$status.RtcmAge
+
+# System (CPU, memory, disk)
+$status.SystemInfo.cpu.Temperature
+$status.SystemInfo.cpu.Usage
+$status.SystemInfo.mem.MemAvailable
+$status.SystemInfo.userdata.disk.availableSize
+
+# LEDs
+$status.LedInfo.led_head
+$status.LedInfo.body_left_r
+$status.HeadLedBrightness
+
+# Telemetry snapshot (same kind of properties)
+$tel = Get-YarboTelemetry
+$tel.RtkSatNum
+$tel.ChuteSteeringRunStatus
+$tel.BatteryCurrent
+```
+
+---
+
+## Recording MQTT and checking coverage
+
+To record real MQTT from your robot and see which topics map to which cmdlets:
+
+```powershell
+.\tools\Record-YarboMqtt.ps1 -DiscoverBroker
+# Or with a known broker:
+.\tools\Record-YarboMqtt.ps1 -Broker 192.168.1.24 -DurationSeconds 60
+```
+
+Then open the generated report or run:
+
+```powershell
+Get-YarboMqttRecordingReport -RecordingPath .\PSYarbo-MqttRecording-<timestamp>.json
+```
+
+See [README](https://github.com/markus-lassfolk/PSYarbo/blob/main/README.md) for full cmdlet lists and installation.
+
+---
+
+## Robot offline or sleeping — what MQTT info do we get?
+
+The MQTT broker runs **on the robot**. What you get depends on whether the robot is reachable and whether it is awake or sleeping.
+
+### Robot completely offline (powered off or not on the network)
+
+- **No MQTT at all.** There is no broker to connect to.
+- `Find-Yarbo` / `Find-YarboDevice` will not return this robot (no TCP, or TCP works but no `heart_beat`/DeviceMSG).
+- `Connect-Yarbo` will fail (TCP connect timeout or connection refused).
+- **You get:** no connection, no status, no telemetry. Use your network tools or cloud app to confirm the robot is on and on the same LAN.
+
+### Robot “sleeping” (suspended / low power, broker still reachable)
+
+If the robot is in sleep mode (e.g. after `Suspend-Yarbo` or auto-sleep), the broker may still accept TCP connections and subscriptions, but the robot often **stops or greatly reduces** publishing:
+
+- **device/DeviceMSG** — full status (battery, RTK, state, etc.) — typically **not published** while sleeping.
+- **device/heart_beat** — simple keepalive with `working_state` — may stop or be rare.
+
+So in practice:
+
+- You **can** often still **connect** (`Connect-Yarbo` succeeds).
+- **get_controller** usually **times out** (robot not responding). You get a warning and the connection is left in **Connected** state without **ControllerAcquired**.
+- **No new DeviceMSG** (and possibly no new heart_beat) until the robot wakes.
+- Commands that send a request and wait for a response (e.g. `Get-YarboStatus` → get_device_msg) will **time out**; you do **not** get fresh status from MQTT.
+
+**What you *do* get in this situation:**
+
+| Source | What you get |
+|--------|-------------------------------|
+| **Connection object** | `State` = Connected, `ControllerAcquired` = false, `Broker`, `SerialNumber`, `ConnectedAt`. |
+| **LastHeartbeat** | Last time a `heart_beat` was received (or `DateTime.MinValue` if none). Stale once the robot is asleep. |
+| **LastWorkingState** | `working_state` from that last heart_beat (0 = idle/sleep). |
+| **Connection.Robot** | Only if at least one **DeviceMSG** was received earlier (e.g. before sleep). That last snapshot is stale. |
+| **Get-YarboStatus** | Times out (no response to get_device_msg). No new data. |
+| **Test-YarboConnection -Detailed** | `Connected` (MQTT client still connected), `HeartbeatAge` (time since last heart_beat), `ControllerAcquired` = false. |
+
+**Example: check if the robot is likely sleeping**
+
+```powershell
+$conn = $conn ?? (Get-YarboConnection)   # your connection
+$detail = Test-YarboConnection -Connection $conn -Detailed
+$detail.Connected          # true = MQTT still connected
+$detail.ControllerAcquired # false = we don't have controller (often means robot sleeping)
+$detail.HeartbeatAge       # time since last heart_beat (e.g. 00:05:00 = 5 minutes)
+$conn.LastWorkingState     # 0 = idle/sleep when we last heard
+# If HeartbeatAge is large and ControllerAcquired is false → robot probably sleeping
+Resume-Yarbo -Connection $conn   # wake the robot, then retry Get-YarboStatus
+```
+
+### Summary
+
+| Robot state | MQTT connection | New DeviceMSG / status | What you can use |
+|-------------|-----------------|------------------------|------------------|
+| **Offline** (off or not on LAN) | No | No | Nothing; fix network/power. |
+| **Sleeping** (broker up, robot not responding) | Yes (usually) | No (timeouts) | Connection metadata, last `Robot` if any, `Test-YarboConnection -Detailed`, `Resume-Yarbo` to wake. |
+| **Active** | Yes | Yes | Full status and telemetry as in the rest of this doc. |
+
+---
+
+## Debug logging and support bundles
+
+To see exactly what is sent and received over MQTT (e.g. for unsupported firmware or heads):
+
+- Use **`-Debug`** on any MQTT cmdlet, or set **`$env:PSYARBO_DEBUG = "1"`** for the whole session. Set **`$env:PSYARBO_DEBUG_RAW = "1"`** for raw (base64) payloads instead of JSON.
+- Use **`Export-YarboSupportBundle -Path ./bundle.json -RecordingPath ./recording.json`** (and/or **`-Connection $conn`**) to produce a redacted JSON file you can attach to an issue or upload to GlitchTip. See README section *Debug logging and support bundles*.

--- a/docs/Commands-and-Properties.md
+++ b/docs/Commands-and-Properties.md
@@ -50,7 +50,7 @@ $status = Get-YarboStatus    # or: Get-YarboRobot
 | `SerialNumber` | string | Robot serial number |
 | `HeadSerialNumber` | string | Attached head serial |
 | `Name` | string | Robot name (if set) — **from cloud only, not MQTT** |
-| `HeadType` | int | Head type identifier |
+| `HeadType` | int | Head type identifier (0=NoHead, 1=SnowBlower, 2=LeafBlower, 3=LawnMower, 4=SmartCover, 5=LawnMowerPro, 99=Trimmer). See `Get-Help about_PSYarbo_Heads` for full list. |
 
 **Robot name (the one you gave it):** Local MQTT does **not** provide the robot’s friendly name. That name comes from the **cloud API**. Use `Get-YarboDevice` (after `Connect-YarboCloud`) to get it; each device has a `.name` property (e.g. `"My Yarbo"`). You can match by `SerialNumber` and assign it to your status object if you want:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@
 ## Quick Links
 
 - 📖 [Full Documentation (README)](https://github.com/markus-lassfolk/PSYarbo/blob/main/README.md)
+- 📋 [Commands and Properties](Commands-and-Properties.md) — how to get status, telemetry, battery, RTK, LEDs, system info
+- 🔧 **In-product help** — After installing: `Get-Help about_PSYarbo`, `Get-Help about_PSYarbo_MQTT`, `Get-Help about_PSYarbo_Debug` (debug logging and support bundles)
 - 🐛 [Report a Bug](https://github.com/markus-lassfolk/PSYarbo/issues/new?template=bug_report.yml)
 - 💡 [Request a Feature](https://github.com/markus-lassfolk/PSYarbo/issues/new?template=feature_request.yml)
 - 💬 [Discussions](https://github.com/markus-lassfolk/PSYarbo/discussions)

--- a/src/PSYarbo/Classes/YarboCloudSession.ps1
+++ b/src/PSYarbo/Classes/YarboCloudSession.ps1
@@ -131,6 +131,9 @@ class YarboCloudSession {
             if ($result.data.refreshToken) {
                 $this.RefreshToken = ConvertTo-SecureString -String $result.data.refreshToken -AsPlainText -Force
             }
+            if ($result.data.snList) {
+                $this.BoundSerialNumbers = @($result.data.snList)
+            }
         } else {
             $codeStr = if ($null -ne $result.code) { $result.code.ToString() } else { 'UNKNOWN' }
             throw [YarboCloudAuthException]::new("Token refresh failed: $($result.message)", $codeStr)

--- a/src/PSYarbo/Classes/YarboConnection.ps1
+++ b/src/PSYarbo/Classes/YarboConnection.ps1
@@ -89,6 +89,11 @@ class YarboConnection {
     # Implement IDisposable — dispose all owned IDisposable members.
     # Disconnect-Yarbo calls this indirectly; classes holding a YarboConnection can also call it directly.
     [void] Dispose() {
+        try {
+            if ($null -ne $this.MqttClient -and [PSYarbo.Mqtt.MessageReceivedAdapter]) {
+                [PSYarbo.Mqtt.MessageReceivedAdapter]::UnregisterCallback($this.MqttClient)
+            }
+        } catch { $null = $_ }
         try { if ($null -ne $this.CancellationSource) { $this.CancellationSource.Dispose() } } catch { $null = $_ }
         try { if ($null -ne $this.CommandSemaphore) { $this.CommandSemaphore.Dispose() } } catch { $null = $_ }
         try { if ($null -ne $this.ResponseSignal) { $this.ResponseSignal.Dispose() } } catch { $null = $_ }

--- a/src/PSYarbo/Classes/YarboConnection.ps1
+++ b/src/PSYarbo/Classes/YarboConnection.ps1
@@ -91,6 +91,10 @@ class YarboConnection {
     [void] Dispose() {
         try {
             if ($null -ne $this.MqttClient -and [PSYarbo.Mqtt.MessageReceivedAdapter]) {
+                $handlerDelegate = [PSYarbo.Mqtt.MessageReceivedAdapter]::GetHandler($this.MqttClient)
+                if ($null -ne $handlerDelegate) {
+                    $this.MqttClient.GetType().GetMethod('remove_ApplicationMessageReceivedAsync').Invoke($this.MqttClient, @($handlerDelegate)) | Out-Null
+                }
                 [PSYarbo.Mqtt.MessageReceivedAdapter]::UnregisterCallback($this.MqttClient)
             }
         } catch { $null = $_ }

--- a/src/PSYarbo/Classes/YarboConnection.ps1
+++ b/src/PSYarbo/Classes/YarboConnection.ps1
@@ -88,14 +88,18 @@ class YarboConnection {
 
     # Implement IDisposable — dispose all owned IDisposable members.
     # Disconnect-Yarbo calls this indirectly; classes holding a YarboConnection can also call it directly.
+    # Resolve adapter type at runtime so the class can load when ScriptsToProcess runs before the .psm1 defines it.
     [void] Dispose() {
         try {
-            if ($null -ne $this.MqttClient -and [PSYarbo.Mqtt.MessageReceivedAdapter]) {
-                $handlerDelegate = [PSYarbo.Mqtt.MessageReceivedAdapter]::GetHandler($this.MqttClient)
-                if ($null -ne $handlerDelegate) {
-                    $this.MqttClient.GetType().GetMethod('remove_ApplicationMessageReceivedAsync').Invoke($this.MqttClient, @($handlerDelegate)) | Out-Null
+            if ($null -ne $this.MqttClient) {
+                $adapterType = [System.AppDomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.GetType('PSYarbo.Mqtt.MessageReceivedAdapter') } | Where-Object { $_ } | Select-Object -First 1
+                if ($null -ne $adapterType) {
+                    $handlerDelegate = $adapterType.GetMethod('GetHandler').Invoke($null, @($this.MqttClient))
+                    if ($null -ne $handlerDelegate) {
+                        $this.MqttClient.GetType().GetMethod('remove_ApplicationMessageReceivedAsync').Invoke($this.MqttClient, @($handlerDelegate)) | Out-Null
+                    }
+                    $adapterType.GetMethod('UnregisterCallback').Invoke($null, @($this.MqttClient))
                 }
-                [PSYarbo.Mqtt.MessageReceivedAdapter]::UnregisterCallback($this.MqttClient)
             }
         } catch { $null = $_ }
         try { if ($null -ne $this.CancellationSource) { $this.CancellationSource.Dispose() } } catch { $null = $_ }

--- a/src/PSYarbo/Classes/YarboEndpoint.ps1
+++ b/src/PSYarbo/Classes/YarboEndpoint.ps1
@@ -1,0 +1,15 @@
+class YarboEndpoint {
+    [string]$IPAddress
+    [int]$Port
+    [string]$Path
+    [string]$MacAddress
+    [bool]$Recommended
+    [string]$Hostname
+    [string]$SerialNumber
+    [string]$Status
+
+    [string] ToString() {
+        $rec = if ($this.Recommended) { ' (recommended)' } else { '' }
+        return "$($this.IPAddress):$($this.Port) $($this.Path)$rec"
+    }
+}

--- a/src/PSYarbo/Classes/YarboGlobalParams.ps1
+++ b/src/PSYarbo/Classes/YarboGlobalParams.ps1
@@ -1,0 +1,20 @@
+<#
+.SYNOPSIS
+    Global robot parameters from read_global_params MQTT response.
+    All fields from the data_feedback payload (MQTT reversing).
+    RawData holds the full decoded payload for any extra keys the device sends.
+#>
+class YarboGlobalParams {
+    [double]$MowSpeed
+    [int]$CuttingHeight
+    [int]$RainDelay
+    [int]$ObstacleSensitivity
+    [double]$Timestamp
+
+    # Full MQTT payload so no keys are lost (e.g. future device fields)
+    [PSCustomObject]$RawData
+
+    [string] ToString() {
+        return "MowSpeed=$($this.MowSpeed) CuttingHeight=$($this.CuttingHeight) RainDelay=$($this.RainDelay) ObstacleSensitivity=$($this.ObstacleSensitivity)"
+    }
+}

--- a/src/PSYarbo/Classes/YarboLightState.ps1
+++ b/src/PSYarbo/Classes/YarboLightState.ps1
@@ -31,6 +31,14 @@ class YarboLightState {
         return [YarboLightState]::new()
     }
 
+    # Body accent lights only (red channels; matches python-yarbo lights_body())
+    static [YarboLightState] BodyOn() {
+        $s = [YarboLightState]::new()
+        $s.BodyLeftRed = 255
+        $s.BodyRightRed = 255
+        return $s
+    }
+
     [string] ToString() {
         return "Head:$($this.HeadLight) L:$($this.LeftWhite) R:$($this.RightWhite) BL:$($this.BodyLeftRed) BR:$($this.BodyRightRed) TL:$($this.TailLeftRed) TR:$($this.TailRightRed)"
     }

--- a/src/PSYarbo/Classes/YarboRobot.ps1
+++ b/src/PSYarbo/Classes/YarboRobot.ps1
@@ -10,6 +10,8 @@ class YarboRobot {
     [int]$BatteryStatus
     [bool]$BatteryTempError
     [double]$BatteryTimestamp
+    [double]$BatteryCurrent
+    [double]$BatteryVoltage
 
     # Body (BodyMsg)
     [int]$RechargeState
@@ -23,6 +25,15 @@ class YarboRobot {
     [bool]$IsRecharging
     [bool]$CarController
     [int]$MachineController
+    [int]$AdjustAngleStatus
+    [int]$AutoDrawWaitingState
+    [int]$EnStateLed
+    [int]$EnWarnLed
+    [bool]$OnGoingToStartPoint
+    [bool]$OnMulPoints
+    [int]$RobotFollowState
+    [int]$ScheduleCancel
+    [int]$VisionAutoDrawState
 
     # Position / Navigation
     [double]$OdometryX
@@ -33,15 +44,43 @@ class YarboRobot {
     [string]$RtkStatus
     [double]$RtkHeadingDop
     [double]$OdomConfidence
+    [double]$RtkGgaAtnDis
+    [double]$RtkHeadingAtnDis
+    [int]$RtkHeadingMulti
+    [int]$RtkHeadingObs
+    [double]$RtkPre4Timestamp
+    [string]$RtkVersion
+    [int]$RtkSatNum
+    [double]$RtkTimestamp
+    [double]$RtcmAge
+    [object]$RtcmInfo
+    [string]$RoverHeading
+    [string]$BaseGngga
 
     # Hardware (RunningStatusMSG, led, wireless_recharge)
     [int]$ChuteAngle
     [int]$RainSensorData
+    [int]$ChuteSteeringEngineInfo
+    [int]$ChuteSteeringRunStatus
+    [double]$HeadGyroPitch
+    [double]$HeadGyroRoll
+    [int]$PushPodStatus
+    [int]$PushRodPlace
+    [int]$SnowPipeRunStatus
+    [int]$SnowRollerMotor
+    [int]$ElecNavigationFrontRightSensor
+    [int]$ElecNavigationRearRightSensor
     [string]$LedRegister
+    [object]$LedInfo
+    [int]$HeadLedBrightness
     [int]$WirelessChargeState
     [double]$WirelessChargeVoltage
     [double]$WirelessChargeCurrent
     [int]$WirelessChargeErrorCode
+    # Electric (EletricMSG)
+    [double]$BrushlessMotorCurrent
+    [double]$NtcTemperature
+    [double]$PushPodCurrent
 
     # Ultrasonic (ultrasonic_msg)
     [int]$UltrasonicLeftFront
@@ -50,6 +89,23 @@ class YarboRobot {
 
     # Network (route_priority)
     [hashtable]$RoutePriority
+
+    # Switches / misc (base_status, bds, bs, ms, s, sbs, tms)
+    [object]$BaseStatus
+    [object]$Bds
+    [object]$Bs
+    [int]$GreenGrassUpdateSwitch
+    [int]$IpcameraOtaSwitch
+    [object]$Ms
+    [object]$S
+    [object]$Sbs
+    [object]$Tms
+
+    # System info (system_info: cpu, mem, userdata)
+    [object]$SystemInfo
+
+    # Debug (DebugMsg)
+    [object]$DebugMsg
 
     # Timestamps (device timestamp + our LastUpdated)
     [double]$DeviceTimestamp

--- a/src/PSYarbo/Classes/YarboRobot.ps1
+++ b/src/PSYarbo/Classes/YarboRobot.ps1
@@ -5,11 +5,16 @@ class YarboRobot {
     [string]$Name
     [int]$HeadType
 
-    # Battery
+    # Battery (BatteryMSG)
     [int]$BatteryCapacity
     [int]$BatteryStatus
+    [bool]$BatteryTempError
+    [double]$BatteryTimestamp
 
-    # State
+    # Body (BodyMsg)
+    [int]$RechargeState
+
+    # State (StateMSG)
     [int]$WorkingState
     [int]$ChargingStatus
     [int]$ErrorCode
@@ -24,24 +29,38 @@ class YarboRobot {
     [double]$OdometryY
     [double]$OdometryPhi
     [double]$Heading
+    [int]$RtkHeadingStatus
     [string]$RtkStatus
+    [double]$RtkHeadingDop
     [double]$OdomConfidence
 
-    # Hardware
+    # Hardware (RunningStatusMSG, led, wireless_recharge)
     [int]$ChuteAngle
+    [int]$RainSensorData
     [string]$LedRegister
+    [int]$WirelessChargeState
     [double]$WirelessChargeVoltage
     [double]$WirelessChargeCurrent
+    [int]$WirelessChargeErrorCode
 
-    # Network
+    # Ultrasonic (ultrasonic_msg)
+    [int]$UltrasonicLeftFront
+    [int]$UltrasonicMiddle
+    [int]$UltrasonicRightFront
+
+    # Network (route_priority)
     [hashtable]$RoutePriority
 
-    # Timestamps
+    # Timestamps (device timestamp + our LastUpdated)
+    [double]$DeviceTimestamp
     [datetime]$LastUpdated
 
     # Connection reference (hidden)
     hidden [string]$Broker
     hidden [int]$Port
+
+    # Full DeviceMSG payload (all MQTT keys available)
+    hidden [PSCustomObject]$RawMessage
 
     [string] ToString() {
         $displayName = if ($this.Name) { $this.Name } else { $this.SerialNumber }

--- a/src/PSYarbo/Classes/YarboTelemetry.ps1
+++ b/src/PSYarbo/Classes/YarboTelemetry.ps1
@@ -20,7 +20,7 @@ class YarboTelemetry {
     [double]$Heading
     [int]$RtkHeadingStatus
     [string]$RtkStatus
-    [double]$RtkDop
+    [double]$RtkHeadingDop
     [double]$OdomConfidence
     [double]$RtkGgaAtnDis
     [double]$RtkHeadingAtnDis

--- a/src/PSYarbo/Classes/YarboTelemetry.ps1
+++ b/src/PSYarbo/Classes/YarboTelemetry.ps1
@@ -7,6 +7,8 @@ class YarboTelemetry {
     [int]$BatteryStatus
     [bool]$BatteryTempError
     [double]$BatteryTimestamp
+    [double]$BatteryCurrent
+    [double]$BatteryVoltage
 
     # Body (BodyMsg)
     [int]$RechargeState
@@ -20,13 +22,32 @@ class YarboTelemetry {
     [string]$RtkStatus
     [double]$RtkDop
     [double]$OdomConfidence
+    [double]$RtkGgaAtnDis
+    [double]$RtkHeadingAtnDis
+    [int]$RtkHeadingMulti
+    [int]$RtkHeadingObs
+    [double]$RtkPre4Timestamp
+    [string]$RtkVersion
+    [int]$RtkSatNum
+    [double]$RtkTimestamp
+    [double]$RtcmAge
+    [object]$RtcmInfo
+    [string]$RoverHeading
+    [string]$BaseGngga
 
     # Running status (RunningStatusMSG)
     [int]$ChuteAngle
     [int]$ChuteSteeringEngineInfo
+    [int]$ChuteSteeringRunStatus
     [double]$HeadGyroPitch
     [double]$HeadGyroRoll
     [int]$RainSensorData
+    [int]$PushPodStatus
+    [int]$PushRodPlace
+    [int]$SnowPipeRunStatus
+    [int]$SnowRollerMotor
+    [int]$ElecNavigationFrontRightSensor
+    [int]$ElecNavigationRearRightSensor
 
     # State (StateMSG)
     [int]$WorkingState
@@ -35,6 +56,15 @@ class YarboTelemetry {
     [bool]$IsPlanning
     [bool]$IsPaused
     [bool]$IsRecharging
+    [int]$AdjustAngleStatus
+    [int]$AutoDrawWaitingState
+    [int]$EnStateLed
+    [int]$EnWarnLed
+    [bool]$OnGoingToStartPoint
+    [bool]$OnMulPoints
+    [int]$RobotFollowState
+    [int]$ScheduleCancel
+    [int]$VisionAutoDrawState
 
     # Sensors (ultrasonic_msg)
     [int]$UltrasonicLeftFront
@@ -47,8 +77,22 @@ class YarboTelemetry {
     [double]$WirelessChargeCurrent
     [int]$WirelessChargeErrorCode
 
-    # LED (led)
+    # LED (led, LedInfoMSG, HeadMsg.head_led_brightness)
     [string]$LedRegister
+    [object]$LedInfo
+    [int]$HeadLedBrightness
+
+    # Electric (EletricMSG)
+    [double]$BrushlessMotorCurrent
+    [double]$NtcTemperature
+    [double]$PushPodCurrent
+
+    # Misc / system
+    [object]$BaseStatus
+    [int]$GreenGrassUpdateSwitch
+    [int]$IpcameraOtaSwitch
+    [object]$SystemInfo
+    [object]$DebugMsg
 
     # GPS (parsed from rtk_base_data.rover.gngga + raw)
     [nullable[double]]$Latitude

--- a/src/PSYarbo/Classes/YarboTelemetry.ps1
+++ b/src/PSYarbo/Classes/YarboTelemetry.ps1
@@ -43,8 +43,8 @@ class YarboTelemetry {
 
     # Wireless charging (wireless_recharge)
     [int]$WirelessChargeState
-    [int]$WirelessChargeVoltage
-    [int]$WirelessChargeCurrent
+    [double]$WirelessChargeVoltage
+    [double]$WirelessChargeCurrent
     [int]$WirelessChargeErrorCode
 
     # LED (led)

--- a/src/PSYarbo/Classes/YarboTelemetry.ps1
+++ b/src/PSYarbo/Classes/YarboTelemetry.ps1
@@ -2,28 +2,33 @@ class YarboTelemetry {
     [datetime]$Timestamp
     [string]$SerialNumber
 
-    # Battery
+    # Battery (BatteryMSG)
     [int]$BatteryCapacity
     [int]$BatteryStatus
     [bool]$BatteryTempError
+    [double]$BatteryTimestamp
 
-    # Position
+    # Body (BodyMsg)
+    [int]$RechargeState
+
+    # Position (CombinedOdom, RTKMSG, combined_odom_confidence)
     [double]$X
     [double]$Y
     [double]$Phi
     [double]$Heading
+    [int]$RtkHeadingStatus
     [string]$RtkStatus
     [double]$RtkDop
     [double]$OdomConfidence
 
-    # Running status
+    # Running status (RunningStatusMSG)
     [int]$ChuteAngle
     [int]$ChuteSteeringEngineInfo
     [double]$HeadGyroPitch
     [double]$HeadGyroRoll
     [int]$RainSensorData
 
-    # State flags
+    # State (StateMSG)
     [int]$WorkingState
     [int]$ChargingStatus
     [int]$ErrorCode
@@ -31,22 +36,29 @@ class YarboTelemetry {
     [bool]$IsPaused
     [bool]$IsRecharging
 
-    # Sensors
+    # Sensors (ultrasonic_msg)
     [int]$UltrasonicLeftFront
     [int]$UltrasonicMiddle
     [int]$UltrasonicRightFront
 
-    # Wireless charging
+    # Wireless charging (wireless_recharge)
     [int]$WirelessChargeState
     [int]$WirelessChargeVoltage
     [int]$WirelessChargeCurrent
     [int]$WirelessChargeErrorCode
 
-    # GPS (parsed from rtk_base_data.rover.gngga NMEA sentence)
+    # LED (led)
+    [string]$LedRegister
+
+    # GPS (parsed from rtk_base_data.rover.gngga + raw)
     [nullable[double]]$Latitude
     [nullable[double]]$Longitude
     [nullable[double]]$Altitude
     [int]$FixQuality
+    [string]$GnggaRaw
+
+    # Device message timestamp (root timestamp)
+    [double]$DeviceTimestamp
 
     # Raw
     hidden [PSCustomObject]$RawMessage

--- a/src/PSYarbo/PSYarbo.Format.ps1xml
+++ b/src/PSYarbo/PSYarbo.Format.ps1xml
@@ -23,10 +23,10 @@
             <TableColumnItems>
               <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>SerialNumber</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>"$($_.BatteryCapacity)%"</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>if($_.WorkingState){'Active'}else{'Idle'}</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>Battery</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>State</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>RtkStatus</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>[math]::Round($_.Heading, 1)</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>HeadingDisplay</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>ErrorCode</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
@@ -34,7 +34,7 @@
       </TableControl>
     </View>
 
-    <!-- YarboRobot List View -->
+    <!-- YarboRobot List View (Battery and State match table view; raw fields kept for scripting) -->
     <View>
       <Name>YarboRobotList</Name>
       <ViewSelectedBy>
@@ -46,6 +46,8 @@
             <ListItems>
               <ListItem><PropertyName>SerialNumber</PropertyName></ListItem>
               <ListItem><PropertyName>Name</PropertyName></ListItem>
+              <ListItem><PropertyName>Battery</PropertyName></ListItem>
+              <ListItem><PropertyName>State</PropertyName></ListItem>
               <ListItem><PropertyName>HeadType</PropertyName></ListItem>
               <ListItem><PropertyName>BatteryCapacity</PropertyName></ListItem>
               <ListItem><PropertyName>BatteryStatus</PropertyName></ListItem>
@@ -53,6 +55,7 @@
               <ListItem><PropertyName>ChargingStatus</PropertyName></ListItem>
               <ListItem><PropertyName>ErrorCode</PropertyName></ListItem>
               <ListItem><PropertyName>Heading</PropertyName></ListItem>
+              <ListItem><PropertyName>HeadingDisplay</PropertyName></ListItem>
               <ListItem><PropertyName>RtkStatus</PropertyName></ListItem>
               <ListItem><PropertyName>OdomConfidence</PropertyName></ListItem>
               <ListItem><PropertyName>ChuteAngle</PropertyName></ListItem>
@@ -83,14 +86,14 @@
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
-              <TableColumnItem><ScriptBlock>$_.Timestamp.ToString('HH:mm:ss.ff')</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>"$($_.BatteryCapacity)%"</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>if($_.WorkingState){'Active'}else{'Idle'}</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>Time</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Battery</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>State</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>RtkStatus</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>[math]::Round($_.Heading, 1)</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>[math]::Round($_.X, 3)</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>[math]::Round($_.Y, 3)</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>[math]::Round($_.OdomConfidence, 3)</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>HeadingDisplay</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>XDisplay</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>YDisplay</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OdomConfidenceDisplay</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>
@@ -129,6 +132,36 @@
       </TableControl>
     </View>
 
+    <!-- YarboEndpoint Table View (issue #30: Rover vs DC discovery) -->
+    <View>
+      <Name>YarboEndpoint</Name>
+      <ViewSelectedBy>
+        <TypeName>YarboEndpoint</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>IPAddress</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Port</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Path</Label><Width>6</Width></TableColumnHeader>
+          <TableColumnHeader><Label>MacAddress</Label><Width>18</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Recommended</Label><Width>12</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Status</Label><Width>10</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>IPAddress</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Port</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Path</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>MacAddress</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>RecommendedDisplay</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Status</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
     <!-- YarboPlan Table View -->
     <View>
       <Name>YarboPlan</Name>
@@ -147,8 +180,8 @@
             <TableColumnItems>
               <TableColumnItem><PropertyName>Id</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>$_.AreaIds -join ', '</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>if($_.EnableSelfOrder){'✓'}else{'✗'}</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>Areas</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>SelfOrder</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>
@@ -178,14 +211,11 @@
               <TableColumnItem><PropertyName>Id</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>PlanId</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>if($_.Enabled){'✓'}else{'✗'}</ScriptBlock></TableColumnItem>
-              <TableColumnItem><ScriptBlock>
-                if ($_.WeekDay -eq 127) { 'Daily' }
-                else { ($_.GetDays() | ForEach-Object { $_.ToString().Substring(0,3) }) -join ',' }
-              </ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>EnabledDisplay</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Days</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>StartTime</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>EndTime</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>if($_.IsWeatherSchedule){'✓'}else{'✗'}</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>WeatherDisplay</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>

--- a/src/PSYarbo/PSYarbo.Types.ps1xml
+++ b/src/PSYarbo/PSYarbo.Types.ps1xml
@@ -11,13 +11,29 @@
   <Type>
     <Name>YarboRobot</Name>
     <Members>
+      <ScriptProperty>
+        <Name>Battery</Name>
+        <GetScriptBlock>"$($this.BatteryCapacity)%"</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>State</Name>
+        <GetScriptBlock>if($this.WorkingState){'Active'}else{'Idle'}</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>HeadingDisplay</Name>
+        <GetScriptBlock>[math]::Round($this.Heading, 1)</GetScriptBlock>
+      </ScriptProperty>
       <PropertySet>
         <Name>DefaultDisplayPropertySet</Name>
         <ReferencedProperties>
           <Name>SerialNumber</Name>
           <Name>Name</Name>
+          <Name>Battery</Name>
+          <Name>State</Name>
+          <Name>HeadingDisplay</Name>
           <Name>HeadType</Name>
           <Name>BatteryCapacity</Name>
+          <Name>BatteryStatus</Name>
           <Name>WorkingState</Name>
           <Name>ChargingStatus</Name>
           <Name>ErrorCode</Name>
@@ -48,19 +64,51 @@
     </Members>
   </Type>
 
-  <!-- YarboTelemetry: key telemetry fields -->
+  <!-- YarboTelemetry: key telemetry fields. Battery and State match YarboRobot for consistent display. -->
   <Type>
     <Name>YarboTelemetry</Name>
     <Members>
+      <ScriptProperty>
+        <Name>Battery</Name>
+        <GetScriptBlock>"$($this.BatteryCapacity)%"</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>State</Name>
+        <GetScriptBlock>if($this.WorkingState){'Active'}else{'Idle'}</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>Time</Name>
+        <GetScriptBlock>$this.Timestamp.ToString('HH:mm:ss.ff')</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>HeadingDisplay</Name>
+        <GetScriptBlock>[math]::Round($this.Heading, 1)</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>XDisplay</Name>
+        <GetScriptBlock>[math]::Round($this.X, 3)</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>YDisplay</Name>
+        <GetScriptBlock>[math]::Round($this.Y, 3)</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>OdomConfidenceDisplay</Name>
+        <GetScriptBlock>[math]::Round($this.OdomConfidence, 3)</GetScriptBlock>
+      </ScriptProperty>
       <PropertySet>
         <Name>DefaultDisplayPropertySet</Name>
         <ReferencedProperties>
+          <Name>Time</Name>
           <Name>Timestamp</Name>
           <Name>SerialNumber</Name>
+          <Name>Battery</Name>
+          <Name>State</Name>
           <Name>BatteryCapacity</Name>
           <Name>WorkingState</Name>
           <Name>RtkStatus</Name>
           <Name>Heading</Name>
+          <Name>HeadingDisplay</Name>
           <Name>X</Name>
           <Name>Y</Name>
           <Name>OdomConfidence</Name>
@@ -69,36 +117,61 @@
     </Members>
   </Type>
 
-  <!-- YarboPlan: key plan fields -->
+  <!-- YarboPlan: key plan fields. Areas and SelfOrder match table view. -->
   <Type>
     <Name>YarboPlan</Name>
     <Members>
+      <ScriptProperty>
+        <Name>Areas</Name>
+        <GetScriptBlock>if($this.AreaIds){$this.AreaIds -join ', '}else{''}</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>SelfOrder</Name>
+        <GetScriptBlock>if($this.EnableSelfOrder){'✓'}else{'✗'}</GetScriptBlock>
+      </ScriptProperty>
       <PropertySet>
         <Name>DefaultDisplayPropertySet</Name>
         <ReferencedProperties>
           <Name>Id</Name>
           <Name>Name</Name>
+          <Name>Areas</Name>
           <Name>AreaIds</Name>
+          <Name>SelfOrder</Name>
           <Name>EnableSelfOrder</Name>
         </ReferencedProperties>
       </PropertySet>
     </Members>
   </Type>
 
-  <!-- YarboSchedule: key schedule fields -->
+  <!-- YarboSchedule: key schedule fields. Days, EnabledDisplay, WeatherDisplay match table view. -->
   <Type>
     <Name>YarboSchedule</Name>
     <Members>
+      <ScriptProperty>
+        <Name>Days</Name>
+        <GetScriptBlock>if($this.WeekDay -eq 127){'Daily'}else{($this.GetDays() | ForEach-Object{$_.ToString().Substring(0,3)}) -join ','}</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>EnabledDisplay</Name>
+        <GetScriptBlock>if($this.Enabled){'✓'}else{'✗'}</GetScriptBlock>
+      </ScriptProperty>
+      <ScriptProperty>
+        <Name>WeatherDisplay</Name>
+        <GetScriptBlock>if($this.IsWeatherSchedule){'✓'}else{'✗'}</GetScriptBlock>
+      </ScriptProperty>
       <PropertySet>
         <Name>DefaultDisplayPropertySet</Name>
         <ReferencedProperties>
           <Name>Id</Name>
           <Name>Name</Name>
           <Name>PlanId</Name>
+          <Name>EnabledDisplay</Name>
           <Name>Enabled</Name>
+          <Name>Days</Name>
           <Name>WeekDay</Name>
           <Name>StartTime</Name>
           <Name>EndTime</Name>
+          <Name>WeatherDisplay</Name>
           <Name>IsWeatherSchedule</Name>
         </ReferencedProperties>
       </PropertySet>
@@ -118,6 +191,29 @@
           <Name>State</Name>
           <Name>Message</Name>
           <Name>Timestamp</Name>
+        </ReferencedProperties>
+      </PropertySet>
+    </Members>
+  </Type>
+
+  <!-- YarboEndpoint: discovery result. RecommendedDisplay matches table view. -->
+  <Type>
+    <Name>YarboEndpoint</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>RecommendedDisplay</Name>
+        <GetScriptBlock>if($this.Recommended){'⭐ Yes'}else{''}</GetScriptBlock>
+      </ScriptProperty>
+      <PropertySet>
+        <Name>DefaultDisplayPropertySet</Name>
+        <ReferencedProperties>
+          <Name>IPAddress</Name>
+          <Name>Port</Name>
+          <Name>Path</Name>
+          <Name>MacAddress</Name>
+          <Name>RecommendedDisplay</Name>
+          <Name>Recommended</Name>
+          <Name>Status</Name>
         </ReferencedProperties>
       </PropertySet>
     </Members>

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -56,7 +56,7 @@
     )
     CmdletsToExport      = @()
     VariablesToExport    = @()
-    AliasesToExport      = @('Return-YarboToDock')
+    AliasesToExport      = @('Return-YarboToDock', 'Start-YarboRecharge')
     PrivateData          = @{
         PSData = @{
             Tags         = @('Yarbo', 'Robot', 'Mower', 'MQTT', 'IoT', 'Automation', 'SnowBlower')

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -52,7 +52,7 @@
         'Set-YarboRobotName', 'Add-YarboRobotBinding', 'Remove-YarboRobotBinding',
         'Get-YarboNotificationSetting', 'Get-YarboDeviceMessage',
         # Utility
-        'Test-YarboConnection', 'Get-YarboLog'
+        'Test-YarboConnection', 'Get-YarboLog', 'Get-YarboMqttRecordingReport'
     )
     CmdletsToExport      = @()
     VariablesToExport    = @()

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -70,7 +70,7 @@
         'Set-YarboRobotName', 'Add-YarboRobotBinding', 'Remove-YarboRobotBinding',
         'Get-YarboNotificationSetting', 'Get-YarboDeviceMessage',
         # Utility
-        'Test-YarboConnection', 'Get-YarboLog', 'Get-YarboMqttRecordingReport'
+        'Test-YarboConnection', 'Get-YarboLog', 'Get-YarboMqttRecordingReport', 'Export-YarboSupportBundle'
     )
     CmdletsToExport      = @()
     VariablesToExport    = @()

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -37,7 +37,7 @@
         'Set-YarboLight', 'Start-YarboBuzzer', 'Stop-YarboBuzzer',
         'Start-YarboPlan', 'Stop-YarboPlan', 'Suspend-YarboPlan', 'Resume-YarboPlan',
         'Send-YarboCommand', 'Send-YarboReturnToDock',
-        'Set-YarboGlobalParams',
+        'Set-YarboGlobalParams', 'Set-YarboBladeSpeed', 'Set-YarboChargeLimit',
         # Robot Control
         'Stop-YarboEmergency', 'Unlock-YarboEmergency', 'Stop-Yarbo',
         'Restart-YarboContainer', 'Stop-YarboShutdown', 'Start-YarboRecharge',
@@ -59,7 +59,7 @@
         'Start-YarboWaypoint', 'Get-YarboRechargePoint', 'Save-YarboChargingPoint',
         'Get-YarboCleanArea', 'Get-YarboMapBackup', 'Save-YarboMapBackup',
         # WiFi & Connectivity
-        'Get-YarboWifiList', 'Get-YarboConnectedWifi', 'Start-YarboHotspot', 'Get-YarboHubInfo',
+        'Get-YarboWifiList', 'Get-YarboConnectedWifi', 'Get-YarboSavedWifiList', 'Start-YarboHotspot', 'Get-YarboHubInfo',
         # Diagnostics
         'Get-YarboBatteryCellTemps', 'Get-YarboMotorTemps', 'Get-YarboBodyCurrent', 'Get-YarboHeadCurrent',
         'Get-YarboSpeed', 'Get-YarboOdometer', 'Get-YarboProductCode', 'Get-YarboNoChargePeriod',

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -37,7 +37,13 @@
         'Set-YarboLight', 'Start-YarboBuzzer', 'Stop-YarboBuzzer',
         'Start-YarboPlan', 'Stop-YarboPlan', 'Suspend-YarboPlan', 'Resume-YarboPlan',
         'Send-YarboCommand', 'Send-YarboReturnToDock',
-        'Set-YarboGlobalParams', 'Set-YarboBladeSpeed', 'Set-YarboChargeLimit',
+        'Set-YarboGlobalParams', 'Set-YarboBladeSpeed', 'Set-YarboChargeLimit', 'Set-YarboBladeHeight', 'Set-YarboTurnType',
+        'Push-YarboSnowDir', 'Set-YarboChuteSteeringWork', 'Set-YarboRollerSpeed',
+        'Set-YarboMotorProtect', 'Set-YarboTrimmer', 'Set-YarboEdgeBlowing', 'Set-YarboSmartBlowing',
+        'Set-YarboHeatingFilm', 'Set-YarboModuleLock', 'Set-YarboFollowState', 'Start-YarboDrawCmd',
+        'Set-YarboGreengrassUpdateSwitch', 'Set-YarboIpcameraOtaSwitch', 'Update-YarboFirmware',
+        'Set-YarboSmartVision', 'Set-YarboVideoRecord', 'Set-YarboBagRecord',
+        'Set-YarboChildLock', 'Set-YarboGeoFence', 'Set-YarboElecFence', 'Set-YarboNgzEdge',
         # Robot Control
         'Stop-YarboEmergency', 'Unlock-YarboEmergency', 'Stop-Yarbo',
         'Restart-YarboContainer', 'Stop-YarboShutdown', 'Start-YarboRecharge',
@@ -45,7 +51,7 @@
         'Set-YarboHeadLight', 'Set-YarboRoofLights', 'Set-YarboLaser',
         'Set-YarboSound', 'Start-YarboSong',
         # Camera & Detection
-        'Set-YarboCamera', 'Set-YarboPersonDetect', 'Set-YarboUSB',
+        'Set-YarboCamera', 'Set-YarboPersonDetect', 'Set-YarboUSB', 'Get-YarboCameraStatus', 'Invoke-YarboCameraCalibration',
         # State
         'Resume-Yarbo', 'Suspend-Yarbo',
         # Manual Drive
@@ -57,7 +63,7 @@
         'Get-YarboAllPlans', 'Remove-YarboAllPlans', 'Invoke-YarboPlanAction', 'Get-YarboSchedules',
         # Navigation & Maps
         'Start-YarboWaypoint', 'Get-YarboRechargePoint', 'Save-YarboChargingPoint',
-        'Get-YarboCleanArea', 'Get-YarboMapBackup', 'Save-YarboMapBackup',
+        'Get-YarboCleanArea', 'Get-YarboMapBackup', 'Save-YarboMapBackup', 'Clear-YarboMap', 'Restore-YarboMap', 'Save-YarboCurrentMap',
         # WiFi & Connectivity
         'Get-YarboWifiList', 'Get-YarboConnectedWifi', 'Get-YarboSavedWifiList', 'Start-YarboHotspot', 'Get-YarboHubInfo',
         # Diagnostics

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -74,7 +74,7 @@
     )
     CmdletsToExport      = @()
     VariablesToExport    = @()
-    AliasesToExport      = @('Return-YarboToDock', 'Start-YarboRecharge')
+    AliasesToExport      = @('Return-YarboToDock')
     PrivateData          = @{
         PSData = @{
             Tags         = @('Yarbo', 'Robot', 'Mower', 'MQTT', 'IoT', 'Automation', 'SnowBlower')

--- a/src/PSYarbo/PSYarbo.psd1
+++ b/src/PSYarbo/PSYarbo.psd1
@@ -10,11 +10,26 @@
     PowerShellVersion    = '7.4'
     # MQTTnet loaded via AssemblyLoadContext in PSYarbo.psm1 — not via RequiredAssemblies
     # RequiredAssemblies = @()
+    # Load class definitions before root module so [YarboRobot], [YarboConnection], etc. are visible to OutputType/attributes
+    ScriptsToProcess     = @(
+        'Classes/YarboExceptions.ps1'
+        'Classes/YarboLightState.ps1'
+        'Classes/YarboCommandResult.ps1'
+        'Classes/YarboTelemetry.ps1'
+        'Classes/YarboPlan.ps1'
+        'Classes/YarboSchedule.ps1'
+        'Classes/YarboRobot.ps1'
+        'Classes/YarboGlobalParams.ps1'
+        'Classes/YarboEndpoint.ps1'
+        'Classes/YarboConnection.ps1'
+        'Classes/YarboCloudSession.ps1'
+    )
     FormatsToProcess     = @('PSYarbo.Format.ps1xml')
-    TypesToProcess       = @('PSYarbo.Types.ps1xml')
+    # Types loaded in .psm1 with Update-TypeData -Force to avoid "already present" on re-import
+    # TypesToProcess       = @('PSYarbo.Types.ps1xml')
     FunctionsToExport    = @(
         # Connection
-        'Connect-Yarbo', 'Disconnect-Yarbo', 'Find-Yarbo',
+        'Connect-Yarbo', 'Disconnect-Yarbo', 'Find-Yarbo', 'Find-YarboDevice', 'Invoke-YarboMqttSniff',
         # Status
         'Get-YarboStatus', 'Get-YarboRobot', 'Get-YarboBattery', 'Get-YarboFirmware',
         'Get-YarboGlobalParams',

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -195,6 +195,7 @@ namespace PSYarbo.Mqtt {
     }
 } else {
     $script:MqttAssembly = $null
+    $script:MqttResolvingHandler = $null
     Write-Warning "MQTTnet.dll not found at '$mqttDllPath'. MQTT cmdlets will not work. Run build/Install-Dependencies.ps1 to download it."
 }
 #endregion

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -27,7 +27,7 @@ if (Test-Path $mqttDllPath) {
     # ApplicationMessageReceivedAsync event is attached with += and always fires.
     $listenerCode = @'
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,7 +35,8 @@ namespace PSYarbo.Mqtt {
     public sealed class YarboMqttListener : IDisposable {
         private readonly MQTTnet.MqttFactory _factory;
         private MQTTnet.Client.IMqttClient _client;
-        private readonly ArrayList _messages = ArrayList.Synchronized(new ArrayList());
+        private readonly object _msgLock = new object();
+        private readonly List<ReceivedMessage> _messages = new List<ReceivedMessage>();
         private readonly TaskCompletionSource<ReceivedMessage> _firstMessage = new TaskCompletionSource<ReceivedMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public YarboMqttListener() {
@@ -48,7 +49,7 @@ namespace PSYarbo.Mqtt {
                 if (len > 0 && seg.Array != null)
                     Buffer.BlockCopy(seg.Array, seg.Offset, copy, 0, len);
                 var msg = new ReceivedMessage(e.ApplicationMessage.Topic ?? "", copy);
-                _messages.Add(msg);
+                lock (_msgLock) { _messages.Add(msg); }
                 if (!_firstMessage.Task.IsCompleted)
                     _firstMessage.TrySetResult(msg);
                 return Task.CompletedTask;
@@ -90,10 +91,11 @@ namespace PSYarbo.Mqtt {
         }
 
         public ReceivedMessage[] GetReceivedMessages() {
-            var arr = new ReceivedMessage[_messages.Count];
-            _messages.CopyTo(arr);
-            _messages.Clear();
-            return arr;
+            lock (_msgLock) {
+                var arr = _messages.ToArray();
+                _messages.Clear();
+                return arr;
+            }
         }
 
         public void Disconnect() {

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -16,13 +16,29 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-#region — Load MQTTnet and C# listener helper
+#region — Load MQTTnet and C# listener helper via isolated AssemblyLoadContext
 $libPath = Join-Path $PSScriptRoot 'lib'
 $mqttDllPath = Join-Path $libPath 'MQTTnet.dll'
 
 if (Test-Path $mqttDllPath) {
-    $script:MqttAssembly = [System.Reflection.Assembly]::LoadFrom((Resolve-Path $mqttDllPath).Path)
-    Write-Verbose "PSYarbo: Loaded MQTTnet from $mqttDllPath"
+    # Load MQTTnet into isolated ALC to avoid version conflicts with other modules
+    $alcName = 'PSYarboMqttContext'
+    $script:MqttALC = [System.Runtime.Loader.AssemblyLoadContext]::new($alcName, $true)
+    $script:MqttAssembly = $script:MqttALC.LoadFromAssemblyPath((Resolve-Path $mqttDllPath).Path)
+    Write-Verbose "PSYarbo: Loaded MQTTnet via isolated AssemblyLoadContext '$alcName'"
+    
+    # Set up assembly resolution so Add-Type can find MQTTnet from the isolated ALC
+    $defaultALC = [System.Runtime.Loader.AssemblyLoadContext]::Default
+    $resolvingHandler = [System.Func[System.Runtime.Loader.AssemblyLoadContext, System.Reflection.AssemblyName, System.Reflection.Assembly]] {
+        param($context, $assemblyName)
+        if ($assemblyName.Name -eq 'MQTTnet') {
+            return $script:MqttAssembly
+        }
+        return $null
+    }
+    $defaultALC.add_Resolving($resolvingHandler)
+    $script:MqttResolvingHandler = $resolvingHandler
+    
     # C# helper: connects, subscribes, and receives messages entirely in C# so the MQTTnet
     # ApplicationMessageReceivedAsync event is attached with += and always fires.
     $listenerCode = @'

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -242,3 +242,12 @@ $script:DefaultConnection = $null
 
 $script:ModuleVersion = (Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot 'PSYarbo.psd1')).ModuleVersion
 Write-Verbose "PSYarbo module loaded. Version: $script:ModuleVersion"
+
+# Register cleanup handler to remove ALC resolving handler on module removal
+$MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
+    if ($script:MqttResolvingHandler) {
+        $defaultALC = [System.Runtime.Loader.AssemblyLoadContext]::Default
+        $defaultALC.remove_Resolving($script:MqttResolvingHandler)
+        $script:MqttResolvingHandler = $null
+    }
+}

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -35,7 +35,7 @@ namespace PSYarbo.Mqtt {
     public sealed class YarboMqttListener : IDisposable {
         private readonly MQTTnet.MqttFactory _factory;
         private MQTTnet.Client.IMqttClient _client;
-        private readonly ArrayList _messages = new ArrayList();
+        private readonly ArrayList _messages = ArrayList.Synchronized(new ArrayList());
         private readonly TaskCompletionSource<ReceivedMessage> _firstMessage = new TaskCompletionSource<ReceivedMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public YarboMqttListener() {
@@ -134,12 +134,27 @@ namespace PSYarbo.Mqtt {
     }
     # Legacy adapter (kept for Connect-Yarbo / Send-MqttCommand response path if still used)
     $adapterCode = @'
+using System.Collections.Generic;
 using System.Threading.Tasks;
 namespace PSYarbo.Mqtt {
     public static class MessageReceivedAdapter {
-        public static System.Func<object, Task> Callback;
-        public static Task Handler(MQTTnet.Client.MqttApplicationMessageReceivedEventArgs ea) {
-            if (Callback != null) return Callback(ea);
+        private static readonly Dictionary<object, System.Func<object, Task>> _callbacks = new Dictionary<object, System.Func<object, Task>>();
+        public static void RegisterCallback(object client, System.Func<object, Task> callback) {
+            lock (_callbacks) {
+                _callbacks[client] = callback;
+            }
+        }
+        public static void UnregisterCallback(object client) {
+            lock (_callbacks) {
+                _callbacks.Remove(client);
+            }
+        }
+        public static Task Handler(object sender, MQTTnet.Client.MqttApplicationMessageReceivedEventArgs ea) {
+            System.Func<object, Task> callback = null;
+            lock (_callbacks) {
+                _callbacks.TryGetValue(sender, out callback);
+            }
+            if (callback != null) return callback(ea);
             return Task.CompletedTask;
         }
     }
@@ -161,7 +176,7 @@ namespace PSYarbo.Mqtt {
 $classFiles = @(
     'YarboExceptions', 'YarboLightState', 'YarboCommandResult',
     'YarboTelemetry', 'YarboPlan', 'YarboSchedule', 'YarboRobot',
-    'YarboEndpoint', 'YarboConnection', 'YarboCloudSession'
+    'YarboGlobalParams', 'YarboEndpoint', 'YarboConnection', 'YarboCloudSession'
 )
 if (-not ('YarboConnection' -as [type])) {
     foreach ($class in $classFiles) {

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -139,23 +139,32 @@ using System.Threading.Tasks;
 namespace PSYarbo.Mqtt {
     public static class MessageReceivedAdapter {
         private static readonly Dictionary<object, System.Func<object, Task>> _callbacks = new Dictionary<object, System.Func<object, Task>>();
+        private static readonly Dictionary<object, System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task>> _handlers = new Dictionary<object, System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task>>();
         public static void RegisterCallback(object client, System.Func<object, Task> callback) {
             lock (_callbacks) {
                 _callbacks[client] = callback;
+                _handlers[client] = ea => {
+                    System.Func<object, Task> cb = null;
+                    lock (_callbacks) {
+                        _callbacks.TryGetValue(client, out cb);
+                    }
+                    if (cb != null) return cb(ea);
+                    return Task.CompletedTask;
+                };
             }
         }
         public static void UnregisterCallback(object client) {
             lock (_callbacks) {
                 _callbacks.Remove(client);
+                _handlers.Remove(client);
             }
         }
-        public static Task Handler(object sender, MQTTnet.Client.MqttApplicationMessageReceivedEventArgs ea) {
-            System.Func<object, Task> callback = null;
+        public static System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task> GetHandler(object client) {
             lock (_callbacks) {
-                _callbacks.TryGetValue(sender, out callback);
+                System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task> handler = null;
+                _handlers.TryGetValue(client, out handler);
+                return handler;
             }
-            if (callback != null) return callback(ea);
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -16,37 +16,158 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-#region — Load MQTTnet via isolated AssemblyLoadContext
+#region — Load MQTTnet and C# listener helper
 $libPath = Join-Path $PSScriptRoot 'lib'
 $mqttDllPath = Join-Path $libPath 'MQTTnet.dll'
 
 if (Test-Path $mqttDllPath) {
-    $alcName = 'PSYarboMqttContext'
-    $script:MqttALC = [System.Runtime.Loader.AssemblyLoadContext]::new($alcName, $true)
-    $script:MqttAssembly = $script:MqttALC.LoadFromAssemblyPath((Resolve-Path $mqttDllPath).Path)
-    Write-Verbose "PSYarbo: Loaded MQTTnet via isolated AssemblyLoadContext '$alcName'"
+    $script:MqttAssembly = [System.Reflection.Assembly]::LoadFrom((Resolve-Path $mqttDllPath).Path)
+    Write-Verbose "PSYarbo: Loaded MQTTnet from $mqttDllPath"
+    # C# helper: connects, subscribes, and receives messages entirely in C# so the MQTTnet
+    # ApplicationMessageReceivedAsync event is attached with += and always fires.
+    $listenerCode = @'
+using System;
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PSYarbo.Mqtt {
+    public sealed class YarboMqttListener : IDisposable {
+        private readonly MQTTnet.MqttFactory _factory;
+        private MQTTnet.Client.IMqttClient _client;
+        private readonly ArrayList _messages = new ArrayList();
+        private readonly TaskCompletionSource<ReceivedMessage> _firstMessage = new TaskCompletionSource<ReceivedMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public YarboMqttListener() {
+            _factory = new MQTTnet.MqttFactory();
+            _client = _factory.CreateMqttClient();
+            _client.ApplicationMessageReceivedAsync += e => {
+                var seg = e.ApplicationMessage.PayloadSegment;
+                int len = seg.Array != null ? seg.Count : 0;
+                byte[] copy = len > 0 ? new byte[len] : Array.Empty<byte>();
+                if (len > 0 && seg.Array != null)
+                    Buffer.BlockCopy(seg.Array, seg.Offset, copy, 0, len);
+                var msg = new ReceivedMessage(e.ApplicationMessage.Topic ?? "", copy);
+                _messages.Add(msg);
+                if (!_firstMessage.Task.IsCompleted)
+                    _firstMessage.TrySetResult(msg);
+                return Task.CompletedTask;
+            };
+        }
+
+        public void Connect(string broker, int port, string clientId, TimeSpan timeout) {
+            var opts = _factory.CreateClientOptionsBuilder()
+                .WithTcpServer(broker, port)
+                .WithClientId(clientId)
+                .WithTimeout(timeout)
+                .Build();
+            _client.ConnectAsync(opts, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public void Subscribe(string[] topicFilters) {
+            var builder = _factory.CreateSubscribeOptionsBuilder();
+            foreach (var topic in topicFilters)
+                builder = builder.WithTopicFilter(topic);
+            var opts = builder.Build();
+            _client.SubscribeAsync(opts, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public void Publish(string topic, byte[] payload) {
+            var msg = _factory.CreateApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(payload ?? Array.Empty<byte>())
+                .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtMostOnce)
+                .Build();
+            _client.PublishAsync(msg, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        public ReceivedMessage WaitForFirstMessage(int timeoutMs) {
+            try {
+                if (_firstMessage.Task.IsCompleted)
+                    return _firstMessage.Task.Result;
+                return _firstMessage.Task.Wait(timeoutMs) ? _firstMessage.Task.Result : null;
+            } catch { return null; }
+        }
+
+        public ReceivedMessage[] GetReceivedMessages() {
+            var arr = new ReceivedMessage[_messages.Count];
+            _messages.CopyTo(arr);
+            _messages.Clear();
+            return arr;
+        }
+
+        public void Disconnect() {
+            try {
+                _client.DisconnectAsync(_factory.CreateClientDisconnectOptionsBuilder().Build(), CancellationToken.None).GetAwaiter().GetResult();
+            } catch { }
+        }
+
+        public void Dispose() {
+            Disconnect();
+            _client?.Dispose();
+            _client = null;
+        }
+
+        public sealed class ReceivedMessage {
+            public string Topic { get; }
+            public byte[] Payload { get; }
+            public ReceivedMessage(string topic, byte[] payload) { Topic = topic; Payload = payload ?? Array.Empty<byte>(); }
+        }
+    }
+}
+'@
+    try {
+        $runtimeDir = [System.Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory()
+        $refAssemblies = @($script:MqttAssembly)
+        foreach ($name in @('netstandard.dll', 'System.Runtime.dll', 'System.Net.Primitives.dll')) {
+            $path = Join-Path $runtimeDir $name
+            if (Test-Path $path) {
+                $refAssemblies += [System.Reflection.Assembly]::LoadFrom((Resolve-Path $path).Path)
+            }
+        }
+        Add-Type -ReferencedAssemblies $refAssemblies -TypeDefinition $listenerCode -ErrorAction Stop
+        Write-Verbose "PSYarbo: YarboMqttListener loaded"
+    } catch {
+        if ($_.Exception.Message -notmatch 'already exists') {
+            Write-Verbose "PSYarbo: YarboMqttListener failed to load: $($_.Exception.Message)"
+        }
+    }
+    # Legacy adapter (kept for Connect-Yarbo / Send-MqttCommand response path if still used)
+    $adapterCode = @'
+using System.Threading.Tasks;
+namespace PSYarbo.Mqtt {
+    public static class MessageReceivedAdapter {
+        public static System.Func<object, Task> Callback;
+        public static Task Handler(MQTTnet.Client.MqttApplicationMessageReceivedEventArgs ea) {
+            if (Callback != null) return Callback(ea);
+            return Task.CompletedTask;
+        }
+    }
+}
+'@
+    try {
+        Add-Type -ReferencedAssemblies $script:MqttAssembly -TypeDefinition $adapterCode -ErrorAction Stop
+    } catch {
+        Write-Verbose "PSYarbo: MessageReceivedAdapter already loaded or failed: $_"
+    }
 } else {
     $script:MqttAssembly = $null
     Write-Warning "MQTTnet.dll not found at '$mqttDllPath'. MQTT cmdlets will not work. Run build/Install-Dependencies.ps1 to download it."
 }
 #endregion
 
-#region — Load classes (order matters)
+# Load classes if not already defined (e.g. when module is loaded via "using module" or in Pester;
+# ScriptsToProcess runs for Import-Module and defines types in caller scope before root module runs).
 $classFiles = @(
-    'YarboExceptions'
-    'YarboLightState'
-    'YarboCommandResult'
-    'YarboTelemetry'
-    'YarboPlan'
-    'YarboSchedule'
-    'YarboRobot'
-    'YarboConnection'
-    'YarboCloudSession'
+    'YarboExceptions', 'YarboLightState', 'YarboCommandResult',
+    'YarboTelemetry', 'YarboPlan', 'YarboSchedule', 'YarboRobot',
+    'YarboEndpoint', 'YarboConnection', 'YarboCloudSession'
 )
-foreach ($class in $classFiles) {
-    . (Join-Path $PSScriptRoot "Classes/$class.ps1")
+if (-not ('YarboConnection' -as [type])) {
+    foreach ($class in $classFiles) {
+        . (Join-Path $PSScriptRoot "Classes/$class.ps1")
+    }
 }
-#endregion
 
 #region — Load private functions
 Get-ChildItem -Path (Join-Path $PSScriptRoot 'Private') -Filter '*.ps1' -Recurse | ForEach-Object {
@@ -60,8 +181,18 @@ Get-ChildItem -Path (Join-Path $PSScriptRoot 'Public') -Filter '*.ps1' -Recurse 
 }
 #endregion
 
+# Load type data with -Force so re-import (Import-Module -Force) overwrites existing definitions
+$typesPath = Join-Path $PSScriptRoot 'PSYarbo.Types.ps1xml'
+if (Test-Path $typesPath) {
+    try {
+        Update-TypeData -Path $typesPath -Force -ErrorAction Stop
+    } catch {
+        Write-Verbose "PSYarbo: Could not load type data: $($_.Exception.Message)"
+    }
+}
+
 #region — Module-scoped state
-$script:YarboConnections = [System.Collections.Generic.Dictionary[string, YarboConnection]]::new()
+$script:YarboConnections = [System.Collections.Generic.Dictionary`2[System.String, YarboConnection]]::new()
 $script:YarboCloudSession = $null
 $script:DefaultConnection = $null
 #endregion

--- a/src/PSYarbo/PSYarbo.psm1
+++ b/src/PSYarbo/PSYarbo.psm1
@@ -136,36 +136,37 @@ namespace PSYarbo.Mqtt {
     }
     # Legacy adapter (kept for Connect-Yarbo / Send-MqttCommand response path if still used)
     $adapterCode = @'
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 namespace PSYarbo.Mqtt {
     public static class MessageReceivedAdapter {
-        private static readonly Dictionary<object, System.Func<object, Task>> _callbacks = new Dictionary<object, System.Func<object, Task>>();
-        private static readonly Dictionary<object, System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task>> _handlers = new Dictionary<object, System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task>>();
+        private static readonly ConditionalWeakTable<object, CallbackEntry> _callbacks = new ConditionalWeakTable<object, CallbackEntry>();
         public static void RegisterCallback(object client, System.Func<object, Task> callback) {
-            lock (_callbacks) {
-                _callbacks[client] = callback;
-                _handlers[client] = ea => {
-                    System.Func<object, Task> cb = null;
-                    lock (_callbacks) {
-                        _callbacks.TryGetValue(client, out cb);
-                    }
-                    if (cb != null) return cb(ea);
-                    return Task.CompletedTask;
-                };
-            }
+            var entry = new CallbackEntry(callback);
+            _callbacks.AddOrUpdate(client, entry);
         }
         public static void UnregisterCallback(object client) {
-            lock (_callbacks) {
-                _callbacks.Remove(client);
-                _handlers.Remove(client);
-            }
+            _callbacks.Remove(client);
         }
         public static System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task> GetHandler(object client) {
-            lock (_callbacks) {
-                System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task> handler = null;
-                _handlers.TryGetValue(client, out handler);
-                return handler;
+            CallbackEntry entry;
+            if (_callbacks.TryGetValue(client, out entry)) {
+                return entry.Handler;
+            }
+            return null;
+        }
+        private sealed class CallbackEntry {
+            public System.Func<object, Task> Callback { get; }
+            public System.Func<MQTTnet.Client.MqttApplicationMessageReceivedEventArgs, Task> Handler { get; }
+            public CallbackEntry(System.Func<object, Task> callback) {
+                Callback = callback;
+                Handler = ea => {
+                    if (Callback != null) return Callback(ea);
+                    return Task.CompletedTask;
+                };
             }
         }
     }

--- a/src/PSYarbo/Private/ArpHelper.ps1
+++ b/src/PSYarbo/Private/ArpHelper.ps1
@@ -1,0 +1,105 @@
+# Private helpers for MAC resolution and locally-administered check (issue #30).
+# Get-MacForIp: Windows (Get-NetNeighbor), Linux (/proc/net/arp, arp -n), macOS (arp -a).
+# Invoke-ArpPrime: ping or TCP touch so the OS ARP table has an entry before lookup.
+
+function Invoke-ArpPrime {
+    <#
+    .SYNOPSIS
+        Ensures the given IP has an ARP entry (pings once) so Get-MacForIp can resolve the MAC.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$IPAddress
+    )
+    if (-not $IPAddress -or $IPAddress -notmatch '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$') { return }
+    try {
+        if ($IsWindows) {
+            $null = Test-Connection -ComputerName $IPAddress -Count 1 -Quiet -ErrorAction SilentlyContinue
+        } else {
+            $null = ping -c 1 -W 1 $IPAddress 2>$null
+        }
+    } catch {
+        Write-Debug "Invoke-ArpPrime $IPAddress : $($_.Exception.Message)"
+    }
+}
+
+function Get-MacForIp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$IPAddress
+    )
+    if (-not $IPAddress -or $IPAddress -notmatch '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$') {
+        return $null
+    }
+    try {
+        if ($IsWindows) {
+            try {
+                $neighbor = Get-NetNeighbor -RemoteIPAddress $IPAddress -ErrorAction Stop
+                if ($neighbor -and $neighbor.LinkLayerAddress) {
+                    return Format-MacAddress $neighbor.LinkLayerAddress
+                }
+            } catch {
+                Write-Debug "Get-NetNeighbor failed, trying arp: $($_.Exception.Message)"
+            }
+            $arpOut = arp -a 2>$null
+            if ($arpOut -match [regex]::Escape($IPAddress)) {
+                $line = $arpOut | Where-Object { $_ -match [regex]::Escape($IPAddress) } | Select-Object -First 1
+                if ($line -match '([0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2})') {
+                    return Format-MacAddress $matches[1]
+                }
+            }
+            return $null
+        }
+        # Linux: /proc/net/arp — columns: IP, HW type, Flags, HW addr, Mask, Device
+        $arpPath = '/proc/net/arp'
+        if (Test-Path $arpPath) {
+            $esc = [regex]::Escape($IPAddress)
+            $line = Get-Content $arpPath -ErrorAction SilentlyContinue | Where-Object { $_ -match "^\s*$esc\s+" } | Select-Object -First 1
+            if ($line -match '^\s*\S+\s+\S+\s+\S+\s+(\S+)\s+') {
+                $mac = $matches[1].Trim()
+                if ($mac -and $mac -ne '00:00:00:00:00:00') {
+                    return Format-MacAddress $mac
+                }
+            }
+        }
+        # Fallback: arp -n (Linux) or arp -a (macOS)
+        $arpOut = arp -n 2>$null
+        if (-not $arpOut) { $arpOut = arp -a 2>$null }
+        if ($arpOut) {
+            $line = $arpOut | Where-Object { $_ -match [regex]::Escape($IPAddress) } | Select-Object -First 1
+            if ($line -match '([0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2})') {
+                return Format-MacAddress $matches[1]
+            }
+        }
+    } catch {
+        Write-Debug "Get-MacForIp $IPAddress : $($_.Exception.Message)"
+    }
+    return $null
+}
+
+function Format-MacAddress {
+    param([string]$Mac)
+    if (-not $Mac) { return $null }
+    $hex = $Mac -replace '[^0-9a-fA-F]', ''
+    if ($hex.Length -ne 12) { return $Mac }
+    return (1..6 | ForEach-Object { $hex.Substring(($_ - 1) * 2, 2) }) -join ':'
+}
+
+function Test-LocallyAdministeredMac {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Mac
+    )
+    if (-not $Mac) { return $false }
+    $hex = $Mac -replace '[^0-9a-fA-F]', ''
+    if ($hex.Length -lt 2) { return $false }
+    try {
+        $firstOctet = [Convert]::ToByte($hex.Substring(0, 2), 16)
+        return ($firstOctet -band 0x02) -eq 0x02
+    } catch {
+        return $false
+    }
+}

--- a/src/PSYarbo/Private/ArpHelper.ps1
+++ b/src/PSYarbo/Private/ArpHelper.ps1
@@ -84,9 +84,10 @@ function Get-MacForIp {
 function Format-MacAddress {
     param([string]$Mac)
     if (-not $Mac) { return $null }
-    $hex = $Mac -replace '[^0-9a-fA-F]', ''
-    if ($hex.Length -ne 12) { return $Mac }
-    return (1..6 | ForEach-Object { $hex.Substring(($_ - 1) * 2, 2) }) -join ':'
+    $octets = $Mac -split '[:-]'
+    if ($octets.Count -ne 6) { return $Mac }
+    $normalized = $octets | ForEach-Object { $_.PadLeft(2, '0') }
+    return $normalized -join ':'
 }
 
 function Test-LocallyAdministeredMac {
@@ -96,10 +97,10 @@ function Test-LocallyAdministeredMac {
         [string]$Mac
     )
     if (-not $Mac) { return $false }
-    $hex = $Mac -replace '[^0-9a-fA-F]', ''
-    if ($hex.Length -lt 2) { return $false }
+    $octets = $Mac -split '[:-]'
+    if ($octets.Count -lt 1 -or -not $octets[0]) { return $false }
     try {
-        $firstOctet = [Convert]::ToByte($hex.Substring(0, 2), 16)
+        $firstOctet = [Convert]::ToByte($octets[0].PadLeft(2, '0'), 16)
         return ($firstOctet -band 0x02) -eq 0x02
     } catch {
         return $false

--- a/src/PSYarbo/Private/ArpHelper.ps1
+++ b/src/PSYarbo/Private/ArpHelper.ps1
@@ -44,8 +44,9 @@ function Get-MacForIp {
                 Write-Debug "Get-NetNeighbor failed, trying arp: $($_.Exception.Message)"
             }
             $arpOut = arp -a 2>$null
-            if ($arpOut -match [regex]::Escape($IPAddress)) {
-                $line = $arpOut | Where-Object { $_ -match [regex]::Escape($IPAddress) } | Select-Object -First 1
+            $esc = [regex]::Escape($IPAddress)
+            if ($arpOut -match "\b$esc\b") {
+                $line = $arpOut | Where-Object { $_ -match "\b$esc\b" } | Select-Object -First 1
                 if ($line -match '([0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2}[:-][0-9a-fA-F]{2})') {
                     return Format-MacAddress $matches[1]
                 }
@@ -68,7 +69,8 @@ function Get-MacForIp {
         $arpOut = arp -n 2>$null
         if (-not $arpOut) { $arpOut = arp -a 2>$null }
         if ($arpOut) {
-            $line = $arpOut | Where-Object { $_ -match [regex]::Escape($IPAddress) } | Select-Object -First 1
+            $esc = [regex]::Escape($IPAddress)
+            $line = $arpOut | Where-Object { $_ -match "\b$esc\b" } | Select-Object -First 1
             if ($line -match '([0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2}[:-][0-9a-fA-F]{1,2})') {
                 return Format-MacAddress $matches[1]
             }

--- a/src/PSYarbo/Private/ConfigManager.ps1
+++ b/src/PSYarbo/Private/ConfigManager.ps1
@@ -30,10 +30,10 @@ function Get-YarboConfig {
 
     $configPath = if ($Path) { $Path } else { $script:YarboConfigFile }
 
-    # Start with defaults
+    # Start with defaults (Port is set later if not overridden)
     $config = @{
         Broker = $null
-        Port   = 1883
+        Port   = $null
         SN     = $null
         Email  = $null
     }
@@ -59,6 +59,11 @@ function Get-YarboConfig {
         }
     }
 
+    # Apply built-in default for Port if not set by config file
+    if ($null -eq $config['Port']) {
+        $config['Port'] = 1883
+    }
+
     # Layer 2: environment variables
     if ($env:YARBO_BROKER) { $config['Broker'] = $env:YARBO_BROKER }
     if ($env:YARBO_SN) { $config['SN'] = $env:YARBO_SN }
@@ -72,78 +77,6 @@ function Get-YarboConfig {
     }
 
     return $config
-}
-
-function Save-YarboConfig {
-    <#
-    .SYNOPSIS
-        Writes the given config object to ~/.psyarbo/config.json (or -Path).
-    .PARAMETER Config
-        Hashtable or PSCustomObject with keys Broker, Port, SN, Email (and optionally defaults, etc.).
-    .PARAMETER Path
-        Optional path. Defaults to ~/.psyarbo/config.json.
-    #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-        'PSUseShouldProcessForStateChangingFunctions', '',
-        Justification = 'Private helper')]
-    param(
-        [Parameter(Mandatory)]
-        [object]$Config,
-
-        [Parameter()]
-        [string]$Path
-    )
-
-    $configPath = if ($Path) { $Path } else { $script:YarboConfigFile }
-    $configDir = Split-Path -Parent $configPath
-    if (-not (Test-Path $configDir)) {
-        $null = New-Item -ItemType Directory -Path $configDir -Force
-    }
-    $obj = if ($Config -is [hashtable]) {
-        $Config
-    } else {
-        $h = @{}
-        $Config.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value }
-        $h
-    }
-    $obj | ConvertTo-Json -Depth 5 | Set-Content -Path $configPath -Encoding UTF8
-    Write-Verbose "PSYarbo: Saved config to $configPath"
-}
-
-function Merge-YarboConfig {
-    <#
-    .SYNOPSIS
-        Merges config hierarchy: defaults &lt; file &lt; env &lt; explicit (highest wins).
-    .PARAMETER Explicit
-        Caller-supplied values (highest priority).
-    .PARAMETER Env
-        Values from environment (e.g. from Get-YarboConfig with no overrides, env-only).
-    .PARAMETER File
-        Values from config file.
-    .PARAMETER Defaults
-        Built-in defaults.
-    #>
-    [OutputType([hashtable])]
-    param(
-        [Parameter()]
-        [hashtable]$Explicit = @{},
-        [Parameter()]
-        [hashtable]$Env = @{},
-        [Parameter()]
-        [hashtable]$File = @{},
-        [Parameter()]
-        [hashtable]$Defaults = @{ Port = 1883 }
-    )
-
-    $result = @{}
-    foreach ($h in @($Defaults, $File, $Env, $Explicit)) {
-        if (-not $h) { continue }
-        foreach ($key in $h.Keys) {
-            $val = $h[$key]
-            if ($null -ne $val -and "$val" -ne '') { $result[$key] = $val }
-        }
-    }
-    return $result
 }
 
 function Set-YarboConfig {

--- a/src/PSYarbo/Private/ConfigManager.ps1
+++ b/src/PSYarbo/Private/ConfigManager.ps1
@@ -9,19 +9,26 @@ function Get-YarboConfig {
         Returns the effective PSYarbo configuration, merging all sources.
     .DESCRIPTION
         Merges configuration from (highest to lowest priority):
-          1. Explicit parameter values already resolved by the caller
+          1. Explicit parameter values (Overrides)
           2. Environment variables (YARBO_BROKER, YARBO_SN, YARBO_PORT, YARBO_EMAIL)
-          3. Config file (~/.psyarbo/config.json)
+          3. Config file (~/.psyarbo/config.json or -Path)
           4. Built-in defaults (Port=1883)
+        Config file may use flat keys (Broker, Port, SN, Email) or schema defaults.broker, defaults.port, defaults.serialNumber.
     .PARAMETER Overrides
         Optional hashtable of caller-supplied values that take highest priority.
-        Null/empty values in Overrides are treated as unset.
+    .PARAMETER Path
+        Optional path to config file. Defaults to ~/.psyarbo/config.json.
     #>
     [OutputType([hashtable])]
     param(
         [Parameter()]
-        [hashtable]$Overrides = @{}
+        [hashtable]$Overrides = @{},
+
+        [Parameter()]
+        [string]$Path
     )
+
+    $configPath = if ($Path) { $Path } else { $script:YarboConfigFile }
 
     # Start with defaults
     $config = @{
@@ -32,15 +39,23 @@ function Get-YarboConfig {
     }
 
     # Layer 1: config file
-    if (Test-Path $script:YarboConfigFile) {
+    if ($configPath -and (Test-Path $configPath)) {
         try {
-            $fileConfig = Get-Content $script:YarboConfigFile -Raw -ErrorAction Stop | ConvertFrom-Json
+            $fileConfig = Get-Content $configPath -Raw -ErrorAction Stop | ConvertFrom-Json
+            # Flat keys
             foreach ($key in 'Broker', 'Port', 'SN', 'Email') {
                 $val = $fileConfig.PSObject.Properties[$key]?.Value
                 if ($null -ne $val -and "$val" -ne '') { $config[$key] = $val }
             }
+            # Schema §10.4: defaults.broker, defaults.port, defaults.serialNumber (fill only if not already set)
+            if ($fileConfig.PSObject.Properties['defaults']) {
+                $d = $fileConfig.defaults
+                if ($null -eq $config['Broker'] -and $d.PSObject.Properties['broker']?.Value) { $config['Broker'] = $d.broker }
+                if ($null -eq $config['Port'] -and $null -ne $d.PSObject.Properties['port']?.Value) { $config['Port'] = [int]$d.port }
+                if ($null -eq $config['SN'] -and $d.PSObject.Properties['serialNumber']?.Value) { $config['SN'] = $d.serialNumber }
+            }
         } catch {
-            Write-Warning "PSYarbo: Could not read config file '$script:YarboConfigFile': $($_.Exception.Message)"
+            Write-Warning "PSYarbo: Could not read config file '$configPath': $($_.Exception.Message)"
         }
     }
 
@@ -50,13 +65,85 @@ function Get-YarboConfig {
     if ($env:YARBO_PORT) { $config['Port'] = [int]$env:YARBO_PORT }
     if ($env:YARBO_EMAIL) { $config['Email'] = $env:YARBO_EMAIL }
 
-    # Layer 3: explicit caller overrides (highest priority, skip null/empty)
+    # Layer 3: explicit caller overrides (highest priority)
     foreach ($key in $Overrides.Keys) {
         $val = $Overrides[$key]
         if ($null -ne $val -and "$val" -ne '') { $config[$key] = $val }
     }
 
     return $config
+}
+
+function Save-YarboConfig {
+    <#
+    .SYNOPSIS
+        Writes the given config object to ~/.psyarbo/config.json (or -Path).
+    .PARAMETER Config
+        Hashtable or PSCustomObject with keys Broker, Port, SN, Email (and optionally defaults, etc.).
+    .PARAMETER Path
+        Optional path. Defaults to ~/.psyarbo/config.json.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Private helper')]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Config,
+
+        [Parameter()]
+        [string]$Path
+    )
+
+    $configPath = if ($Path) { $Path } else { $script:YarboConfigFile }
+    $configDir = Split-Path -Parent $configPath
+    if (-not (Test-Path $configDir)) {
+        $null = New-Item -ItemType Directory -Path $configDir -Force
+    }
+    $obj = if ($Config -is [hashtable]) {
+        $Config
+    } else {
+        $h = @{}
+        $Config.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value }
+        $h
+    }
+    $obj | ConvertTo-Json -Depth 5 | Set-Content -Path $configPath -Encoding UTF8
+    Write-Verbose "PSYarbo: Saved config to $configPath"
+}
+
+function Merge-YarboConfig {
+    <#
+    .SYNOPSIS
+        Merges config hierarchy: defaults &lt; file &lt; env &lt; explicit (highest wins).
+    .PARAMETER Explicit
+        Caller-supplied values (highest priority).
+    .PARAMETER Env
+        Values from environment (e.g. from Get-YarboConfig with no overrides, env-only).
+    .PARAMETER File
+        Values from config file.
+    .PARAMETER Defaults
+        Built-in defaults.
+    #>
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [hashtable]$Explicit = @{},
+        [Parameter()]
+        [hashtable]$Env = @{},
+        [Parameter()]
+        [hashtable]$File = @{},
+        [Parameter()]
+        [hashtable]$Defaults = @{ Port = 1883 }
+    )
+
+    $result = @{}
+    foreach ($h in @($Defaults, $File, $Env, $Explicit)) {
+        if (-not $h) { continue }
+        foreach ($key in $h.Keys) {
+            $val = $h[$key]
+            if ($null -ne $val -and "$val" -ne '') { $result[$key] = $val }
+        }
+    }
+    return $result
 }
 
 function Set-YarboConfig {

--- a/src/PSYarbo/Private/CredentialHelper.ps1
+++ b/src/PSYarbo/Private/CredentialHelper.ps1
@@ -216,7 +216,7 @@ function Save-YarboCloudCredential {
         [Parameter(Mandatory)]
         [string]$Email,
 
-        [Parameter(Mandatory)]
+        [Parameter()]
         [SecureString]$Password,
 
         [Parameter()]
@@ -224,7 +224,9 @@ function Save-YarboCloudCredential {
     )
 
     $safeKey = $Email -replace '[^a-zA-Z0-9._@-]', '_'
-    Save-YarboCredential -Name "$safeKey-Password" -Value $Password
+    if ($Password) {
+        Save-YarboCredential -Name "$safeKey-Password" -Value $Password
+    }
     if ($RefreshToken) {
         Save-YarboCredential -Name "$safeKey-RefreshToken" -Value $RefreshToken
     }

--- a/src/PSYarbo/Private/CredentialHelper.ps1
+++ b/src/PSYarbo/Private/CredentialHelper.ps1
@@ -170,6 +170,66 @@ function Get-YarboCredential {
     }
 }
 
+function Get-YarboCloudCredential {
+    <#
+    .SYNOPSIS
+        Retrieves stored cloud credentials for an email (password and/or refresh token).
+    .DESCRIPTION
+        Returns a hashtable with Password and RefreshToken (SecureString or $null) for the given email.
+        Used by Connect-YarboCloud when -Email is provided without -Password.
+    .PARAMETER Email
+        The account email used as the credential key.
+    .OUTPUTS
+        [hashtable] @{ Password = [SecureString]; RefreshToken = [SecureString] } or $null if neither found.
+    #>
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Email
+    )
+
+    $safeKey = $Email -replace '[^a-zA-Z0-9._@-]', '_'
+    $passwordName = "$safeKey-Password"
+    $tokenName = "$safeKey-RefreshToken"
+
+    $password = Get-YarboCredential -Name $passwordName
+    $refreshToken = Get-YarboCredential -Name $tokenName
+    if (-not $password -and -not $refreshToken) { return $null }
+    return @{ Password = $password; RefreshToken = $refreshToken }
+}
+
+function Save-YarboCloudCredential {
+    <#
+    .SYNOPSIS
+        Saves cloud password and optional refresh token keyed by email (SecretManagement or file fallback).
+    .PARAMETER Email
+        The account email (used as the credential key).
+    .PARAMETER Password
+        The account password (SecureString).
+    .PARAMETER RefreshToken
+        Optional refresh token to store for future sessions.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Private credential helper')]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Email,
+
+        [Parameter(Mandatory)]
+        [SecureString]$Password,
+
+        [Parameter()]
+        [SecureString]$RefreshToken
+    )
+
+    $safeKey = $Email -replace '[^a-zA-Z0-9._@-]', '_'
+    Save-YarboCredential -Name "$safeKey-Password" -Value $Password
+    if ($RefreshToken) {
+        Save-YarboCredential -Name "$safeKey-RefreshToken" -Value $RefreshToken
+    }
+}
+
 function Remove-YarboCredential {
     <#
     .SYNOPSIS

--- a/src/PSYarbo/Private/DebugOutput.ps1
+++ b/src/PSYarbo/Private/DebugOutput.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Helpers for debug logging: env-based and -Debug switch support (aligns with python-yarbo #59).
+#>
+
+function Test-YarboDebugMode {
+    <#
+    .SYNOPSIS
+        Returns true when debug output should be shown: -Debug was passed or PSYARBO_DEBUG env is set.
+    #>
+    [OutputType([bool])]
+    param()
+    if ($DebugPreference -eq 'Continue') { return $true }
+    $v = $env:PSYARBO_DEBUG
+    return ($v -eq '1' -or $v -eq 'true' -or $v -eq 'True')
+}
+
+function Test-YarboDebugRaw {
+    <#
+    .SYNOPSIS
+        Returns true when debug output should show raw payloads (base64) instead of human-readable JSON.
+    #>
+    [OutputType([bool])]
+    param()
+    $v = $env:PSYARBO_DEBUG_RAW
+    return ($v -eq '1' -or $v -eq 'true' -or $v -eq 'True')
+}
+
+function Write-YarboDebugMessage {
+    <#
+    .SYNOPSIS
+        Writes a debug line. Uses Write-Debug when -Debug was passed; uses Write-Information when PSYARBO_DEBUG env is set so output shows without -Debug.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message
+    )
+    $msg = Protect-YarboLogMessage -Message $Message
+    if ($env:PSYARBO_DEBUG -eq '1' -or $env:PSYARBO_DEBUG -eq 'true' -or $env:PSYARBO_DEBUG -eq 'True') {
+        Write-Information $msg -InformationAction Continue
+    } else {
+        Write-Debug $msg
+    }
+}

--- a/src/PSYarbo/Private/MqttTransport.ps1
+++ b/src/PSYarbo/Private/MqttTransport.ps1
@@ -31,7 +31,14 @@ function Send-MqttCommand {
 
     # Compress payload
     $compressed = ConvertTo-ZlibPayload -Payload $Payload
-    Write-Debug (Protect-YarboLogMessage "[Send-MqttCommand] Payload JSON: $($Payload | ConvertTo-Json -Compress)")
+    if (Test-YarboDebugMode) {
+        $payloadStr = if (Test-YarboDebugRaw) {
+            "[raw base64] $([Convert]::ToBase64String($compressed))"
+        } else {
+            "Payload: $($Payload | ConvertTo-Json -Compress)"
+        }
+        Write-YarboDebugMessage "[Send-MqttCommand] SENT $topic | $payloadStr"
+    }
 
     # Acquire semaphore to serialize commands
     if (-not $Connection.CommandSemaphore.Wait(30000)) {
@@ -81,6 +88,14 @@ function Send-MqttCommand {
             if ($Connection.ResponseQueue.TryDequeue([ref]$response)) {
                 if ($response.topic -eq $Command) {
                     $result = [YarboCommandResult]::new($response)
+                    if (Test-YarboDebugMode) {
+                        $respStr = if (Test-YarboDebugRaw) {
+                            "state=$($result.State) msg=$($result.Message) data=$(if ($result.Data) { $result.Data | ConvertTo-Json -Compress } else { 'null' })"
+                        } else {
+                            "Received: topic=$($result.Topic) state=$($result.State) message=$($result.Message)" + $(if ($result.Data) { " data=$($result.Data | ConvertTo-Json -Compress)" } else { '' })
+                        }
+                        Write-YarboDebugMessage "[Send-MqttCommand] RECV $Command | $respStr"
+                    }
                     # Log response
                     $Connection.CommandLog.Enqueue([PSCustomObject]@{
                             Timestamp = [datetime]::UtcNow
@@ -92,7 +107,11 @@ function Send-MqttCommand {
                     return $result
                 }
                 # Not our response — could be for a different command, re-enqueue and re-signal
-                Write-Debug (Protect-YarboLogMessage "[Send-MqttCommand] Got feedback for '$($response.topic)' while waiting for '$Command'")
+                if (Test-YarboDebugMode) {
+                    Write-YarboDebugMessage "[Send-MqttCommand] Got feedback for '$($response.topic)' while waiting for '$Command'"
+                } else {
+                    Write-Debug (Protect-YarboLogMessage "[Send-MqttCommand] Got feedback for '$($response.topic)' while waiting for '$Command'")
+                }
                 $Connection.ResponseQueue.Enqueue($response)
                 $Connection.ResponseSignal.Release() | Out-Null
                 # Brief yield to prevent a tight CPU spin when responses keep arriving for other commands
@@ -101,7 +120,11 @@ function Send-MqttCommand {
         }
 
         # Timeout
-        Write-Debug (Protect-YarboLogMessage "[Send-MqttCommand] Timeout waiting for '$Command' after ${TimeoutMs}ms on $topic @ $($Connection.Broker):$($Connection.Port)")
+        if (Test-YarboDebugMode) {
+            Write-YarboDebugMessage "[Send-MqttCommand] Timeout waiting for '$Command' after ${TimeoutMs}ms on $topic @ $($Connection.Broker):$($Connection.Port)"
+        } else {
+            Write-Debug (Protect-YarboLogMessage "[Send-MqttCommand] Timeout waiting for '$Command' after ${TimeoutMs}ms on $topic @ $($Connection.Broker):$($Connection.Port)")
+        }
 
         if ($ThrowOnTimeout) {
             throw [YarboTimeoutException]::new($Command, $TimeoutMs)
@@ -134,6 +157,14 @@ function Send-MqttFireAndForget {
     Write-Verbose (Protect-YarboLogMessage "[Send-MqttFireAndForget] Routing via local MQTT → $topic @ $($Connection.Broker):$($Connection.Port)")
 
     $compressed = ConvertTo-ZlibPayload -Payload $Payload
+    if (Test-YarboDebugMode) {
+        $payloadStr = if (Test-YarboDebugRaw) {
+            "[raw base64] $([Convert]::ToBase64String($compressed))"
+        } else {
+            "Payload: $($Payload | ConvertTo-Json -Compress)"
+        }
+        Write-YarboDebugMessage "[Send-MqttFireAndForget] SENT $topic | $payloadStr"
+    }
 
     if ($null -eq $Connection.MqttClient) {
         throw [YarboConnectionException]::new("MQTT client is not connected.", $Connection.Broker)

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -63,7 +63,7 @@ function Get-PSYarboSubnetIpList {
         $maxInSubnet = [math]::Pow(2, $hostBits) - 2
         $take = [math]::Min([int]$maxInSubnet, $remaining)
         for ($i = 1; $i -le $take; $i++) {
-            $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
+            $ipVal = $baseVal + $i
             $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
             [Array]::Reverse($newBytes)
             $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -59,7 +59,6 @@ function Get-PSYarboSubnetIpList {
         $hostBits = 32 - $prefixLen
         $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
         $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
-        $baseBytes = [System.BitConverter]::GetBytes($baseVal)
         $maxInSubnet = [math]::Pow(2, $hostBits) - 2
         $take = [math]::Min([int]$maxInSubnet, $remaining)
         for ($i = 1; $i -le $take; $i++) {

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -1,5 +1,59 @@
 # Returns CIDR subnets for all local IPv4 addresses (LAN, Wi‑Fi, etc.) so discovery can scan "my networks" by default.
 
+function Get-PSYarboSubnetIpList {
+    <#
+    .SYNOPSIS
+        Generates a list of host IPs from CIDR subnets for network scanning.
+    
+    .PARAMETER Subnets
+        Array of CIDR subnet strings (e.g., '192.168.1.0/24').
+    
+    .PARAMETER MaxHosts
+        Maximum number of host IPs to generate across all subnets.
+    
+    .OUTPUTS
+        [string[]] Array of IP addresses to scan.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Subnets,
+        
+        [Parameter(Mandatory)]
+        [int]$MaxHosts
+    )
+    
+    $ipList = [System.Collections.Generic.List[string]]::new()
+    $remaining = $MaxHosts
+    
+    foreach ($oneSubnet in $Subnets) {
+        if ($remaining -le 0) { break }
+        $parts = $oneSubnet -split '/'
+        if ($parts.Count -lt 2) { continue }
+        $prefixLen = [int]$parts[1]
+        if ($prefixLen -lt 16 -or $prefixLen -gt 30) { continue }
+        $baseIp = [System.Net.IPAddress]::Parse($parts[0].Trim())
+        $baseBytes = $baseIp.GetAddressBytes()
+        [Array]::Reverse($baseBytes)
+        $hostBits = 32 - $prefixLen
+        $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
+        $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
+        $baseBytes = [System.BitConverter]::GetBytes($baseVal)
+        $maxInSubnet = [math]::Pow(2, $hostBits) - 2
+        $take = [math]::Min([int]$maxInSubnet, $remaining)
+        for ($i = 1; $i -le $take; $i++) {
+            $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
+            $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
+            [Array]::Reverse($newBytes)
+            $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())
+        }
+        $remaining -= $take
+    }
+    
+    return $ipList.ToArray()
+}
+
 function Get-PSYarboLocalSubnets {
     [CmdletBinding()]
     [OutputType([string[]])]

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -6,7 +6,7 @@ function Get-PSYarboSubnetIpList {
         Generates a list of host IPs from CIDR subnets for network scanning.
     
     .PARAMETER Subnets
-        Array of CIDR subnet strings (e.g., '192.168.1.0/24').
+        Array of CIDR subnet strings (e.g., '192.0.2.0/24').
     
     .PARAMETER MaxHosts
         Maximum number of host IPs to generate across all subnets.

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -38,16 +38,16 @@ function Get-PSYarboSubnetIpList {
         $parts = $oneSubnet -split '/'
         if ($parts.Count -lt 2) { continue }
         $prefixLen = [int]$parts[1]
-        if ($prefixLen -lt 16 -or $prefixLen -gt 30) {
+        if ($prefixLen -lt 16 -or $prefixLen -gt 31) {
             if ($ValidateUserInput) {
                 if ($prefixLen -lt 16) {
                     throw [System.ArgumentException]::new(
                         "Subnet prefix /$prefixLen is too large for safety. Use /16 or longer."
                     )
                 }
-                if ($prefixLen -gt 30) {
+                if ($prefixLen -gt 31) {
                     throw [System.ArgumentException]::new(
-                        "Subnet prefix /$prefixLen has no scannable host addresses. Use /30 or shorter."
+                        "Subnet prefix /$prefixLen has no scannable host addresses. Use /31 or shorter."
                     )
                 }
             }
@@ -59,10 +59,16 @@ function Get-PSYarboSubnetIpList {
         $hostBits = 32 - $prefixLen
         $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
         $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
-        $maxInSubnet = [math]::Pow(2, $hostBits) - 2
+        if ($prefixLen -eq 31) {
+            $maxInSubnet = 2
+            $startOffset = 0
+        } else {
+            $maxInSubnet = [math]::Pow(2, $hostBits) - 2
+            $startOffset = 1
+        }
         $take = [math]::Min([int]$maxInSubnet, $remaining)
-        for ($i = 1; $i -le $take; $i++) {
-            $ipVal = $baseVal + $i
+        for ($i = 0; $i -lt $take; $i++) {
+            $ipVal = $baseVal + $startOffset + $i
             $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
             [Array]::Reverse($newBytes)
             $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())
@@ -88,7 +94,7 @@ function Get-PSYarboLocalSubnet {
                 if ($addr.Address.AddressFamily -ne [System.Net.Sockets.AddressFamily]::InterNetwork) { continue }
                 $ip = $addr.Address
                 $plen = $addr.PrefixLength
-                if ($plen -lt 16 -or $plen -gt 30) { continue }
+                if ($plen -lt 16 -or $plen -gt 31) { continue }
                 $bytes = $ip.GetAddressBytes()
                 [Array]::Reverse($bytes)
                 $val = [System.BitConverter]::ToUInt32($bytes, 0)

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -11,6 +11,9 @@ function Get-PSYarboSubnetIpList {
     .PARAMETER MaxHosts
         Maximum number of host IPs to generate across all subnets.
     
+    .PARAMETER ValidateUserInput
+        When true, throws an exception for invalid subnet prefixes instead of silently skipping them.
+    
     .OUTPUTS
         [string[]] Array of IP addresses to scan.
     #>
@@ -21,7 +24,10 @@ function Get-PSYarboSubnetIpList {
         [string[]]$Subnets,
         
         [Parameter(Mandatory)]
-        [int]$MaxHosts
+        [int]$MaxHosts,
+        
+        [Parameter()]
+        [switch]$ValidateUserInput
     )
     
     $ipList = [System.Collections.Generic.List[string]]::new()
@@ -32,7 +38,21 @@ function Get-PSYarboSubnetIpList {
         $parts = $oneSubnet -split '/'
         if ($parts.Count -lt 2) { continue }
         $prefixLen = [int]$parts[1]
-        if ($prefixLen -lt 16 -or $prefixLen -gt 30) { continue }
+        if ($prefixLen -lt 16 -or $prefixLen -gt 30) {
+            if ($ValidateUserInput) {
+                if ($prefixLen -lt 16) {
+                    throw [System.ArgumentException]::new(
+                        "Subnet prefix /$prefixLen is too large for safety. Use /16 or longer."
+                    )
+                }
+                if ($prefixLen -gt 30) {
+                    throw [System.ArgumentException]::new(
+                        "Subnet prefix /$prefixLen has no scannable host addresses. Use /30 or shorter."
+                    )
+                }
+            }
+            continue
+        }
         $baseIp = [System.Net.IPAddress]::Parse($parts[0].Trim())
         $baseBytes = $baseIp.GetAddressBytes()
         [Array]::Reverse($baseBytes)

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -54,7 +54,7 @@ function Get-PSYarboSubnetIpList {
     return $ipList.ToArray()
 }
 
-function Get-PSYarboLocalSubnets {
+function Get-PSYarboLocalSubnet {
     [CmdletBinding()]
     [OutputType([string[]])]
     param()
@@ -87,6 +87,6 @@ function Get-PSYarboLocalSubnets {
             }
         }
     } catch {
-        Write-Debug "Get-PSYarboLocalSubnets: $($_.Exception.Message)"
+        Write-Debug "Get-PSYarboLocalSubnet: $($_.Exception.Message)"
     }
 }

--- a/src/PSYarbo/Private/NetworkHelper.ps1
+++ b/src/PSYarbo/Private/NetworkHelper.ps1
@@ -1,0 +1,38 @@
+# Returns CIDR subnets for all local IPv4 addresses (LAN, Wi‑Fi, etc.) so discovery can scan "my networks" by default.
+
+function Get-PSYarboLocalSubnets {
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+    $seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    try {
+        $adapters = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()
+        foreach ($a in $adapters) {
+            if ($a.OperationalStatus -ne [System.Net.NetworkInformation.OperationalStatus]::Up) { continue }
+            if ($a.NetworkInterfaceType -eq [System.Net.NetworkInformation.NetworkInterfaceType]::Loopback) { continue }
+            $props = $a.GetIPProperties()
+            foreach ($addr in $props.UnicastAddresses) {
+                if ($addr.Address.AddressFamily -ne [System.Net.Sockets.AddressFamily]::InterNetwork) { continue }
+                $ip = $addr.Address
+                $plen = $addr.PrefixLength
+                if ($plen -lt 16 -or $plen -gt 30) { continue }
+                $bytes = $ip.GetAddressBytes()
+                [Array]::Reverse($bytes)
+                $val = [System.BitConverter]::ToUInt32($bytes, 0)
+                $mask = [uint32]::MaxValue -shl (32 - $plen)
+                $netVal = $val -band $mask
+                $netBytes = [System.BitConverter]::GetBytes([uint32]$netVal)
+                [Array]::Reverse($netBytes)
+                $netIp = [System.Net.IPAddress]::new($netBytes)
+                $cidr = "$($netIp)/$plen"
+                if ($addr.Address.ToString().StartsWith('169.254.')) { continue }
+                if (-not $seen.Contains($cidr)) {
+                    $null = $seen.Add($cidr)
+                    $cidr
+                }
+            }
+        }
+    } catch {
+        Write-Debug "Get-PSYarboLocalSubnets: $($_.Exception.Message)"
+    }
+}

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -121,7 +121,7 @@ function ConvertTo-YarboTelemetry {
         $t.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
         $rtk = $DeviceMsg.RTKMSG.PSObject.Properties
         if ($rtk['heading_status']) { $t.RtkHeadingStatus = [int]$rtk['heading_status'].Value }
-        if ($rtk['heading_dop']) { $t.RtkDop = [double]$rtk['heading_dop'].Value }
+        if ($rtk['heading_dop']) { $t.RtkHeadingDop = [double]$rtk['heading_dop'].Value }
         if ($rtk['gga_atn_dis']) { $t.RtkGgaAtnDis = [double]$rtk['gga_atn_dis'].Value }
         if ($rtk['heading_atn_dis']) { $t.RtkHeadingAtnDis = [double]$rtk['heading_atn_dis'].Value }
         if ($rtk['heading_multi']) { $t.RtkHeadingMulti = [int]$rtk['heading_multi'].Value }

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -151,8 +151,8 @@ function ConvertTo-YarboTelemetry {
     # Wireless charging
     if ($DeviceMsg.wireless_recharge) {
         $t.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
-        $t.WirelessChargeVoltage = [int]($DeviceMsg.wireless_recharge.output_voltage)
-        $t.WirelessChargeCurrent = [int]($DeviceMsg.wireless_recharge.output_current)
+        $t.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
+        $t.WirelessChargeCurrent = [double]($DeviceMsg.wireless_recharge.output_current)
         $t.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
     }
 

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -99,13 +99,13 @@ function ConvertTo-YarboTelemetry {
         $t.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
         $t.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $t.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
-        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
-        if ($null -ne $DeviceMsg.BatteryMSG.current) { $t.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
-        if ($null -ne $DeviceMsg.BatteryMSG.voltage) { $t.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
+        if ($DeviceMsg.BatteryMSG.PSObject.Properties["timestamp"]) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        if ($DeviceMsg.BatteryMSG.PSObject.Properties["current"]) { $t.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
+        if ($DeviceMsg.BatteryMSG.PSObject.Properties["voltage"]) { $t.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
     }
 
     # Body (BodyMsg)
-    if ($DeviceMsg.BodyMsg -and $null -ne $DeviceMsg.BodyMsg.recharge_state) {
+    if ($DeviceMsg.BodyMsg -and $DeviceMsg.BodyMsg.PSObject.Properties["recharge_state"]) {
         $t.RechargeState = [int]($DeviceMsg.BodyMsg.recharge_state)
     }
 
@@ -118,40 +118,40 @@ function ConvertTo-YarboTelemetry {
 
     if ($DeviceMsg.RTKMSG) {
         $t.Heading = [double]($DeviceMsg.RTKMSG.heading)
-        if ($null -ne $DeviceMsg.RTKMSG.heading_status) { $t.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_status"]) { $t.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $t.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        if ($null -ne $DeviceMsg.RTKMSG.heading_dop) { $t.RtkDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
-        if ($null -ne $DeviceMsg.RTKMSG.gga_atn_dis) { $t.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
-        if ($null -ne $DeviceMsg.RTKMSG.heading_atn_dis) { $t.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
-        if ($null -ne $DeviceMsg.RTKMSG.heading_multi) { $t.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
-        if ($null -ne $DeviceMsg.RTKMSG.heading_obs) { $t.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
-        if ($null -ne $DeviceMsg.RTKMSG.pre4_timestamp) { $t.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
-        if ($null -ne $DeviceMsg.RTKMSG.rtk_version) { $t.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
-        if ($null -ne $DeviceMsg.RTKMSG.sat_num) { $t.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
-        if ($null -ne $DeviceMsg.RTKMSG.timestamp) { $t.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_dop"]) { $t.RtkDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["gga_atn_dis"]) { $t.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_atn_dis"]) { $t.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_multi"]) { $t.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_obs"]) { $t.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["pre4_timestamp"]) { $t.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["rtk_version"]) { $t.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["sat_num"]) { $t.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["timestamp"]) { $t.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
     }
-    if ($null -ne $DeviceMsg.combined_odom_confidence) {
+    if ($DeviceMsg.PSObject.Properties["combined_odom_confidence"]) {
         $t.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
     }
-    if ($null -ne $DeviceMsg.rtcm_age) { $t.RtcmAge = [double]($DeviceMsg.rtcm_age) }
-    if ($null -ne $DeviceMsg.rtcm_info) { $t.RtcmInfo = $DeviceMsg.rtcm_info }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $null -ne $DeviceMsg.rtk_base_data.rover.heading) { $t.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.base -and $null -ne $DeviceMsg.rtk_base_data.base.gngga) { $t.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
+    if ($DeviceMsg.PSObject.Properties["rtcm_age"]) { $t.RtcmAge = [double]($DeviceMsg.rtcm_age) }
+    if ($DeviceMsg.PSObject.Properties["rtcm_info"]) { $t.RtcmInfo = $DeviceMsg.rtcm_info }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["rover"] -and $DeviceMsg.rtk_base_data.rover.PSObject.Properties["heading"]) { $t.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["base"] -and $DeviceMsg.rtk_base_data.base.PSObject.Properties["gngga"]) { $t.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
 
     # Running status
     if ($DeviceMsg.RunningStatusMSG) {
         $t.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
         $t.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data)
-        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_engine_info) { $t.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_run_status) { $t.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_pitch) { $t.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_roll) { $t.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.push_pod_status) { $t.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.push_rod_place) { $t.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_pipe_run_status) { $t.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_roller_motor) { $t.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) { $t.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) { $t.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_engine_info"]) { $t.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_run_status"]) { $t.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_pitch"]) { $t.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_roll"]) { $t.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_pod_status"]) { $t.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_rod_place"]) { $t.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_pipe_run_status"]) { $t.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_roller_motor"]) { $t.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_front_right_sensor"]) { $t.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_rear_right_sensor"]) { $t.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
     }
 
     # State
@@ -162,15 +162,15 @@ function ConvertTo-YarboTelemetry {
         $t.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
         $t.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
         $t.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
-        if ($null -ne $DeviceMsg.StateMSG.adjustangle_status) { $t.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
-        if ($null -ne $DeviceMsg.StateMSG.auto_draw_waiting_state) { $t.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
-        if ($null -ne $DeviceMsg.StateMSG.en_state_led) { $t.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
-        if ($null -ne $DeviceMsg.StateMSG.en_warn_led) { $t.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
-        if ($null -ne $DeviceMsg.StateMSG.on_going_to_start_point) { $t.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
-        if ($null -ne $DeviceMsg.StateMSG.on_mul_points) { $t.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
-        if ($null -ne $DeviceMsg.StateMSG.robot_follow_state) { $t.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
-        if ($null -ne $DeviceMsg.StateMSG.schedule_cancel) { $t.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
-        if ($null -ne $DeviceMsg.StateMSG.vision_auto_draw_state) { $t.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["adjustangle_status"]) { $t.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["auto_draw_waiting_state"]) { $t.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["en_state_led"]) { $t.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["en_warn_led"]) { $t.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["on_going_to_start_point"]) { $t.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["on_mul_points"]) { $t.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["robot_follow_state"]) { $t.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["schedule_cancel"]) { $t.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["vision_auto_draw_state"]) { $t.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
     }
 
     # Ultrasonic sensors
@@ -189,26 +189,26 @@ function ConvertTo-YarboTelemetry {
     }
 
     # LED (led, LedInfoMSG, HeadMsg.head_led_brightness)
-    if ($null -ne $DeviceMsg.led) { $t.LedRegister = [string]($DeviceMsg.led) }
-    if ($null -ne $DeviceMsg.LedInfoMSG) { $t.LedInfo = $DeviceMsg.LedInfoMSG }
-    if ($DeviceMsg.HeadMsg -and $null -ne $DeviceMsg.HeadMsg.head_led_brightness) { $t.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
+    if ($DeviceMsg.PSObject.Properties["led"]) { $t.LedRegister = [string]($DeviceMsg.led) }
+    if ($DeviceMsg.PSObject.Properties["LedInfoMSG"]) { $t.LedInfo = $DeviceMsg.LedInfoMSG }
+    if ($DeviceMsg.HeadMsg -and $DeviceMsg.HeadMsg.PSObject.Properties["head_led_brightness"]) { $t.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
 
     # Electric (EletricMSG)
-    if ($null -ne $DeviceMsg.EletricMSG) {
-        if ($null -ne $DeviceMsg.EletricMSG.brushless_motor_current) { $t.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
-        if ($null -ne $DeviceMsg.EletricMSG.ntc_temperature) { $t.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
-        if ($null -ne $DeviceMsg.EletricMSG.push_pod_current) { $t.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
+    if ($DeviceMsg.PSObject.Properties["EletricMSG"]) {
+        if ($DeviceMsg.EletricMSG.PSObject.Properties["brushless_motor_current"]) { $t.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
+        if ($DeviceMsg.EletricMSG.PSObject.Properties["ntc_temperature"]) { $t.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
+        if ($DeviceMsg.EletricMSG.PSObject.Properties["push_pod_current"]) { $t.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
     }
 
     # Misc (base_status, switches, system_info, DebugMsg)
-    if ($null -ne $DeviceMsg.base_status) { $t.BaseStatus = $DeviceMsg.base_status }
-    if ($null -ne $DeviceMsg.green_grass_update_switch) { $t.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
-    if ($null -ne $DeviceMsg.ipcamera_ota_switch) { $t.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
-    if ($null -ne $DeviceMsg.system_info) { $t.SystemInfo = $DeviceMsg.system_info }
-    if ($null -ne $DeviceMsg.DebugMsg) { $t.DebugMsg = $DeviceMsg.DebugMsg }
+    if ($DeviceMsg.PSObject.Properties["base_status"]) { $t.BaseStatus = $DeviceMsg.base_status }
+    if ($DeviceMsg.PSObject.Properties["green_grass_update_switch"]) { $t.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
+    if ($DeviceMsg.PSObject.Properties["ipcamera_ota_switch"]) { $t.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
+    if ($DeviceMsg.PSObject.Properties["system_info"]) { $t.SystemInfo = $DeviceMsg.system_info }
+    if ($DeviceMsg.PSObject.Properties["DebugMsg"]) { $t.DebugMsg = $DeviceMsg.DebugMsg }
 
     # Device message timestamp (root)
-    if ($null -ne $DeviceMsg.timestamp) { $t.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
+    if ($DeviceMsg.PSObject.Properties["timestamp"]) { $t.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
 
     # GPS — parse GNGGA NMEA sentence from rtk_base_data.rover.gngga
     if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $DeviceMsg.rtk_base_data.rover.gngga) {
@@ -260,13 +260,13 @@ function ConvertTo-YarboRobot {
         $r.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
         $r.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $r.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
-        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
-        if ($null -ne $DeviceMsg.BatteryMSG.current) { $r.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
-        if ($null -ne $DeviceMsg.BatteryMSG.voltage) { $r.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
+        if ($DeviceMsg.BatteryMSG.PSObject.Properties["timestamp"]) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        if ($DeviceMsg.BatteryMSG.PSObject.Properties["current"]) { $r.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
+        if ($DeviceMsg.BatteryMSG.PSObject.Properties["voltage"]) { $r.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
     }
 
     # Body (BodyMsg)
-    if ($DeviceMsg.BodyMsg -and $null -ne $DeviceMsg.BodyMsg.recharge_state) {
+    if ($DeviceMsg.BodyMsg -and $DeviceMsg.BodyMsg.PSObject.Properties["recharge_state"]) {
         $r.RechargeState = [int]($DeviceMsg.BodyMsg.recharge_state)
     }
 
@@ -279,16 +279,16 @@ function ConvertTo-YarboRobot {
         $r.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
         $r.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
         $r.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
-        if ($null -ne $DeviceMsg.StateMSG.adjustangle_status) { $r.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
-        if ($null -ne $DeviceMsg.StateMSG.auto_draw_waiting_state) { $r.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
-        if ($null -ne $DeviceMsg.StateMSG.car_controller) { $r.CarController = [bool]($DeviceMsg.StateMSG.car_controller) }
-        if ($null -ne $DeviceMsg.StateMSG.en_state_led) { $r.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
-        if ($null -ne $DeviceMsg.StateMSG.en_warn_led) { $r.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
-        if ($null -ne $DeviceMsg.StateMSG.on_going_to_start_point) { $r.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
-        if ($null -ne $DeviceMsg.StateMSG.on_mul_points) { $r.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
-        if ($null -ne $DeviceMsg.StateMSG.robot_follow_state) { $r.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
-        if ($null -ne $DeviceMsg.StateMSG.schedule_cancel) { $r.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
-        if ($null -ne $DeviceMsg.StateMSG.vision_auto_draw_state) { $r.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["adjustangle_status"]) { $r.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["auto_draw_waiting_state"]) { $r.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["car_controller"]) { $r.CarController = [bool]($DeviceMsg.StateMSG.car_controller) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["en_state_led"]) { $r.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["en_warn_led"]) { $r.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["on_going_to_start_point"]) { $r.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["on_mul_points"]) { $r.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["robot_follow_state"]) { $r.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["schedule_cancel"]) { $r.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
+        if ($DeviceMsg.StateMSG.PSObject.Properties["vision_auto_draw_state"]) { $r.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
     }
 
     # Position
@@ -299,44 +299,44 @@ function ConvertTo-YarboRobot {
     }
     if ($DeviceMsg.RTKMSG) {
         $r.Heading = [double]($DeviceMsg.RTKMSG.heading)
-        if ($null -ne $DeviceMsg.RTKMSG.heading_status) { $r.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_status"]) { $r.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $r.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        if ($null -ne $DeviceMsg.RTKMSG.heading_dop) { $r.RtkHeadingDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
-        if ($null -ne $DeviceMsg.RTKMSG.gga_atn_dis) { $r.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
-        if ($null -ne $DeviceMsg.RTKMSG.heading_atn_dis) { $r.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
-        if ($null -ne $DeviceMsg.RTKMSG.heading_multi) { $r.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
-        if ($null -ne $DeviceMsg.RTKMSG.heading_obs) { $r.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
-        if ($null -ne $DeviceMsg.RTKMSG.pre4_timestamp) { $r.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
-        if ($null -ne $DeviceMsg.RTKMSG.rtk_version) { $r.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
-        if ($null -ne $DeviceMsg.RTKMSG.sat_num) { $r.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
-        if ($null -ne $DeviceMsg.RTKMSG.timestamp) { $r.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_dop"]) { $r.RtkHeadingDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["gga_atn_dis"]) { $r.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_atn_dis"]) { $r.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_multi"]) { $r.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_obs"]) { $r.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["pre4_timestamp"]) { $r.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["rtk_version"]) { $r.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["sat_num"]) { $r.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
+        if ($DeviceMsg.RTKMSG.PSObject.Properties["timestamp"]) { $r.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
     }
-    if ($null -ne $DeviceMsg.combined_odom_confidence) {
+    if ($DeviceMsg.PSObject.Properties["combined_odom_confidence"]) {
         $r.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
     }
-    if ($null -ne $DeviceMsg.rtcm_age) { $r.RtcmAge = [double]($DeviceMsg.rtcm_age) }
-    if ($null -ne $DeviceMsg.rtcm_info) { $r.RtcmInfo = $DeviceMsg.rtcm_info }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $null -ne $DeviceMsg.rtk_base_data.rover.heading) { $r.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.base -and $null -ne $DeviceMsg.rtk_base_data.base.gngga) { $r.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
+    if ($DeviceMsg.PSObject.Properties["rtcm_age"]) { $r.RtcmAge = [double]($DeviceMsg.rtcm_age) }
+    if ($DeviceMsg.PSObject.Properties["rtcm_info"]) { $r.RtcmInfo = $DeviceMsg.rtcm_info }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["rover"] -and $DeviceMsg.rtk_base_data.rover.PSObject.Properties["heading"]) { $r.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["base"] -and $DeviceMsg.rtk_base_data.base.PSObject.Properties["gngga"]) { $r.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
 
     # Hardware (RunningStatusMSG, led, wireless_recharge)
     if ($DeviceMsg.RunningStatusMSG) {
         $r.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
-        if ($null -ne $DeviceMsg.RunningStatusMSG.rain_sensor_data) { $r.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_engine_info) { $r.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_run_status) { $r.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_pitch) { $r.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_roll) { $r.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.push_pod_status) { $r.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.push_rod_place) { $r.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_pipe_run_status) { $r.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_roller_motor) { $r.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) { $r.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
-        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) { $r.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["rain_sensor_data"]) { $r.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_engine_info"]) { $r.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_run_status"]) { $r.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_pitch"]) { $r.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_roll"]) { $r.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_pod_status"]) { $r.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_rod_place"]) { $r.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_pipe_run_status"]) { $r.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_roller_motor"]) { $r.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_front_right_sensor"]) { $r.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
+        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_rear_right_sensor"]) { $r.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
     }
-    if ($null -ne $DeviceMsg.led) { $r.LedRegister = [string]($DeviceMsg.led) }
-    if ($null -ne $DeviceMsg.LedInfoMSG) { $r.LedInfo = $DeviceMsg.LedInfoMSG }
-    if ($DeviceMsg.HeadMsg -and $null -ne $DeviceMsg.HeadMsg.head_led_brightness) { $r.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
+    if ($DeviceMsg.PSObject.Properties["led"]) { $r.LedRegister = [string]($DeviceMsg.led) }
+    if ($DeviceMsg.PSObject.Properties["LedInfoMSG"]) { $r.LedInfo = $DeviceMsg.LedInfoMSG }
+    if ($DeviceMsg.HeadMsg -and $DeviceMsg.HeadMsg.PSObject.Properties["head_led_brightness"]) { $r.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
     if ($DeviceMsg.wireless_recharge) {
         $r.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
         $r.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
@@ -352,7 +352,7 @@ function ConvertTo-YarboRobot {
     }
 
     # Device message timestamp (root)
-    if ($null -ne $DeviceMsg.timestamp) { $r.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
+    if ($DeviceMsg.PSObject.Properties["timestamp"]) { $r.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
 
     # Network (route_priority)
     if ($DeviceMsg.route_priority) {
@@ -361,21 +361,21 @@ function ConvertTo-YarboRobot {
     }
 
     # Misc / switches / system / debug
-    if ($null -ne $DeviceMsg.base_status) { $r.BaseStatus = $DeviceMsg.base_status }
-    if ($null -ne $DeviceMsg.bds) { $r.Bds = $DeviceMsg.bds }
-    if ($null -ne $DeviceMsg.bs) { $r.Bs = $DeviceMsg.bs }
-    if ($null -ne $DeviceMsg.green_grass_update_switch) { $r.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
-    if ($null -ne $DeviceMsg.ipcamera_ota_switch) { $r.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
-    if ($null -ne $DeviceMsg.ms) { $r.Ms = $DeviceMsg.ms }
-    if ($null -ne $DeviceMsg.s) { $r.S = $DeviceMsg.s }
-    if ($null -ne $DeviceMsg.sbs) { $r.Sbs = $DeviceMsg.sbs }
-    if ($null -ne $DeviceMsg.tms) { $r.Tms = $DeviceMsg.tms }
-    if ($null -ne $DeviceMsg.system_info) { $r.SystemInfo = $DeviceMsg.system_info }
-    if ($null -ne $DeviceMsg.DebugMsg) { $r.DebugMsg = $DeviceMsg.DebugMsg }
-    if ($null -ne $DeviceMsg.EletricMSG) {
-        if ($null -ne $DeviceMsg.EletricMSG.brushless_motor_current) { $r.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
-        if ($null -ne $DeviceMsg.EletricMSG.ntc_temperature) { $r.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
-        if ($null -ne $DeviceMsg.EletricMSG.push_pod_current) { $r.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
+    if ($DeviceMsg.PSObject.Properties["base_status"]) { $r.BaseStatus = $DeviceMsg.base_status }
+    if ($DeviceMsg.PSObject.Properties["bds"]) { $r.Bds = $DeviceMsg.bds }
+    if ($DeviceMsg.PSObject.Properties["bs"]) { $r.Bs = $DeviceMsg.bs }
+    if ($DeviceMsg.PSObject.Properties["green_grass_update_switch"]) { $r.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
+    if ($DeviceMsg.PSObject.Properties["ipcamera_ota_switch"]) { $r.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
+    if ($DeviceMsg.PSObject.Properties["ms"]) { $r.Ms = $DeviceMsg.ms }
+    if ($DeviceMsg.PSObject.Properties["s"]) { $r.S = $DeviceMsg.s }
+    if ($DeviceMsg.PSObject.Properties["sbs"]) { $r.Sbs = $DeviceMsg.sbs }
+    if ($DeviceMsg.PSObject.Properties["tms"]) { $r.Tms = $DeviceMsg.tms }
+    if ($DeviceMsg.PSObject.Properties["system_info"]) { $r.SystemInfo = $DeviceMsg.system_info }
+    if ($DeviceMsg.PSObject.Properties["DebugMsg"]) { $r.DebugMsg = $DeviceMsg.DebugMsg }
+    if ($DeviceMsg.PSObject.Properties["EletricMSG"]) {
+        if ($DeviceMsg.EletricMSG.PSObject.Properties["brushless_motor_current"]) { $r.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
+        if ($DeviceMsg.EletricMSG.PSObject.Properties["ntc_temperature"]) { $r.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
+        if ($DeviceMsg.EletricMSG.PSObject.Properties["push_pod_current"]) { $r.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
     }
 
     return $r

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -75,6 +75,140 @@ function ConvertFrom-GnggaSentence {
     return $result
 }
 
+function Set-YarboCommonFields {
+    <#
+    .SYNOPSIS
+        Maps common DeviceMSG fields to a target object (YarboTelemetry or YarboRobot).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$DeviceMsg,
+
+        [Parameter(Mandatory)]
+        [object]$Target
+    )
+
+    # Battery (BatteryMSG)
+    if ($DeviceMsg.BatteryMSG) {
+        $Target.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
+        $Target.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
+        $Target.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
+        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $Target.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        $cur = $DeviceMsg.BatteryMSG.PSObject.Properties['current']; if ($cur) { $Target.BatteryCurrent = [double]$cur.Value }
+        $vol = $DeviceMsg.BatteryMSG.PSObject.Properties['voltage']; if ($vol) { $Target.BatteryVoltage = [double]$vol.Value }
+    }
+
+    # State (StateMSG)
+    if ($DeviceMsg.StateMSG) {
+        $Target.WorkingState = [int]($DeviceMsg.StateMSG.working_state)
+        $Target.ChargingStatus = [int]($DeviceMsg.StateMSG.charging_status)
+        $Target.ErrorCode = [int]($DeviceMsg.StateMSG.error_code)
+        $Target.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
+        $Target.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
+        $Target.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
+        $state = $DeviceMsg.StateMSG.PSObject.Properties
+        if ($state['adjustangle_status']) { $Target.AdjustAngleStatus = [int]$state['adjustangle_status'].Value }
+        if ($state['auto_draw_waiting_state']) { $Target.AutoDrawWaitingState = [int]$state['auto_draw_waiting_state'].Value }
+        if ($state['en_state_led']) { $Target.EnStateLed = [int]$state['en_state_led'].Value }
+        if ($state['en_warn_led']) { $Target.EnWarnLed = [int]$state['en_warn_led'].Value }
+        if ($state['on_going_to_start_point']) { $Target.OnGoingToStartPoint = ([int]$state['on_going_to_start_point'].Value -gt 0) }
+        if ($state['on_mul_points']) { $Target.OnMulPoints = ([int]$state['on_mul_points'].Value -gt 0) }
+        if ($state['robot_follow_state']) { $Target.RobotFollowState = [int]$state['robot_follow_state'].Value }
+        if ($state['schedule_cancel']) { $Target.ScheduleCancel = [int]$state['schedule_cancel'].Value }
+        if ($state['vision_auto_draw_state']) { $Target.VisionAutoDrawState = [int]$state['vision_auto_draw_state'].Value }
+    }
+
+    # RTKMSG
+    if ($DeviceMsg.RTKMSG) {
+        $Target.Heading = [double]($DeviceMsg.RTKMSG.heading)
+        $Target.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
+        $rtk = $DeviceMsg.RTKMSG.PSObject.Properties
+        if ($rtk['heading_status']) { $Target.RtkHeadingStatus = [int]$rtk['heading_status'].Value }
+        if ($rtk['heading_dop']) { $Target.RtkHeadingDop = [double]$rtk['heading_dop'].Value }
+        if ($rtk['gga_atn_dis']) { $Target.RtkGgaAtnDis = [double]$rtk['gga_atn_dis'].Value }
+        if ($rtk['heading_atn_dis']) { $Target.RtkHeadingAtnDis = [double]$rtk['heading_atn_dis'].Value }
+        if ($rtk['heading_multi']) { $Target.RtkHeadingMulti = [int]$rtk['heading_multi'].Value }
+        if ($rtk['heading_obs']) { $Target.RtkHeadingObs = [int]$rtk['heading_obs'].Value }
+        if ($rtk['pre4_timestamp']) { $Target.RtkPre4Timestamp = [double]$rtk['pre4_timestamp'].Value }
+        if ($rtk['rtk_version']) { $Target.RtkVersion = [string]$rtk['rtk_version'].Value }
+        if ($rtk['sat_num']) { $Target.RtkSatNum = [int]$rtk['sat_num'].Value }
+        if ($rtk['timestamp']) { $Target.RtkTimestamp = [double]$rtk['timestamp'].Value }
+    }
+    $root = $DeviceMsg.PSObject.Properties
+    if ($root['combined_odom_confidence']) { $Target.OdomConfidence = [double]$root['combined_odom_confidence'].Value }
+    if ($root['rtcm_age']) { $Target.RtcmAge = [double]$root['rtcm_age'].Value }
+    if ($root['rtcm_info']) { $Target.RtcmInfo = $root['rtcm_info'].Value }
+    if ($DeviceMsg.rtk_base_data) {
+        $rbd = $DeviceMsg.rtk_base_data.PSObject.Properties
+        if ($rbd['rover']) {
+            $roverProp = $rbd['rover'].Value.PSObject.Properties['heading']
+            if ($roverProp) { $Target.RoverHeading = [string]$roverProp.Value }
+        }
+        if ($rbd['base']) {
+            $baseProp = $rbd['base'].Value.PSObject.Properties['gngga']
+            if ($baseProp) { $Target.BaseGngga = [string]$baseProp.Value }
+        }
+    }
+
+    # RunningStatusMSG
+    if ($DeviceMsg.RunningStatusMSG) {
+        $Target.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
+        $run = $DeviceMsg.RunningStatusMSG.PSObject.Properties
+        if ($run['rain_sensor_data']) { $Target.RainSensorData = [int]$run['rain_sensor_data'].Value }
+        if ($run['chute_steering_engine_info']) { $Target.ChuteSteeringEngineInfo = [int]$run['chute_steering_engine_info'].Value }
+        if ($run['chute_steering_run_status']) { $Target.ChuteSteeringRunStatus = [int]$run['chute_steering_run_status'].Value }
+        if ($run['head_gyro_pitch']) { $Target.HeadGyroPitch = [double]$run['head_gyro_pitch'].Value }
+        if ($run['head_gyro_roll']) { $Target.HeadGyroRoll = [double]$run['head_gyro_roll'].Value }
+        if ($run['push_pod_status']) { $Target.PushPodStatus = [int]$run['push_pod_status'].Value }
+        if ($run['push_rod_place']) { $Target.PushRodPlace = [int]$run['push_rod_place'].Value }
+        if ($run['snow_pipe_run_status']) { $Target.SnowPipeRunStatus = [int]$run['snow_pipe_run_status'].Value }
+        if ($run['snow_roller_motor']) { $Target.SnowRollerMotor = [int]$run['snow_roller_motor'].Value }
+        if ($run['elec_navigation_front_right_sensor']) { $Target.ElecNavigationFrontRightSensor = [int]$run['elec_navigation_front_right_sensor'].Value }
+        if ($run['elec_navigation_rear_right_sensor']) { $Target.ElecNavigationRearRightSensor = [int]$run['elec_navigation_rear_right_sensor'].Value }
+    }
+
+    # Ultrasonic sensors
+    if ($DeviceMsg.ultrasonic_msg) {
+        $Target.UltrasonicLeftFront = [int]($DeviceMsg.ultrasonic_msg.lf_dis)
+        $Target.UltrasonicMiddle = [int]($DeviceMsg.ultrasonic_msg.mt_dis)
+        $Target.UltrasonicRightFront = [int]($DeviceMsg.ultrasonic_msg.rf_dis)
+    }
+
+    # Wireless charging
+    if ($DeviceMsg.wireless_recharge) {
+        $Target.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
+        $Target.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
+        $Target.WirelessChargeCurrent = [double]($DeviceMsg.wireless_recharge.output_current)
+        $Target.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
+    }
+
+    # LED (led, LedInfoMSG, HeadMsg.head_led_brightness)
+    if ($root['led']) { $Target.LedRegister = [string]$root['led'].Value }
+    if ($root['LedInfoMSG']) { $Target.LedInfo = $root['LedInfoMSG'].Value }
+    if ($DeviceMsg.HeadMsg) {
+        $headProp = $DeviceMsg.HeadMsg.PSObject.Properties['head_led_brightness']
+        if ($headProp) { $Target.HeadLedBrightness = [int]$headProp.Value }
+    }
+
+    # Electric (EletricMSG)
+    if ($root['EletricMSG']) {
+        $elec = $root['EletricMSG'].Value.PSObject.Properties
+        if ($elec['brushless_motor_current']) { $Target.BrushlessMotorCurrent = [double]$elec['brushless_motor_current'].Value }
+        if ($elec['ntc_temperature']) { $Target.NtcTemperature = [double]$elec['ntc_temperature'].Value }
+        if ($elec['push_pod_current']) { $Target.PushPodCurrent = [double]$elec['push_pod_current'].Value }
+    }
+
+    # Misc (base_status, switches, system_info, DebugMsg)
+    if ($root['base_status']) { $Target.BaseStatus = $root['base_status'].Value }
+    if ($root['green_grass_update_switch']) { $Target.GreenGrassUpdateSwitch = [int]$root['green_grass_update_switch'].Value }
+    if ($root['ipcamera_ota_switch']) { $Target.IpcameraOtaSwitch = [int]$root['ipcamera_ota_switch'].Value }
+    if ($root['system_info']) { $Target.SystemInfo = $root['system_info'].Value }
+    if ($root['DebugMsg']) { $Target.DebugMsg = $root['DebugMsg'].Value }
+
+    # Device message timestamp (root)
+    if ($root['timestamp']) { $Target.DeviceTimestamp = [double]$root['timestamp'].Value }
+}
+
 function ConvertTo-YarboTelemetry {
     <#
     .SYNOPSIS
@@ -94,15 +228,7 @@ function ConvertTo-YarboTelemetry {
     $t.SerialNumber = $SerialNumber
     $t.RawMessage = $DeviceMsg
 
-    # Battery (BatteryMSG)
-    if ($DeviceMsg.BatteryMSG) {
-        $t.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
-        $t.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
-        $t.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
-        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
-        $cur = $DeviceMsg.BatteryMSG.PSObject.Properties['current']; if ($cur) { $t.BatteryCurrent = [double]$cur.Value }
-        $vol = $DeviceMsg.BatteryMSG.PSObject.Properties['voltage']; if ($vol) { $t.BatteryVoltage = [double]$vol.Value }
-    }
+    Set-YarboCommonFields -DeviceMsg $DeviceMsg -Target $t
 
     # Body (BodyMsg)
     if ($DeviceMsg.BodyMsg -and $DeviceMsg.BodyMsg.PSObject.Properties["recharge_state"]) {
@@ -115,115 +241,6 @@ function ConvertTo-YarboTelemetry {
         $t.Y = [double]($DeviceMsg.CombinedOdom.y)
         $t.Phi = [double]($DeviceMsg.CombinedOdom.phi)
     }
-
-    if ($DeviceMsg.RTKMSG) {
-        $t.Heading = [double]($DeviceMsg.RTKMSG.heading)
-        $t.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        $rtk = $DeviceMsg.RTKMSG.PSObject.Properties
-        if ($rtk['heading_status']) { $t.RtkHeadingStatus = [int]$rtk['heading_status'].Value }
-        if ($rtk['heading_dop']) { $t.RtkHeadingDop = [double]$rtk['heading_dop'].Value }
-        if ($rtk['gga_atn_dis']) { $t.RtkGgaAtnDis = [double]$rtk['gga_atn_dis'].Value }
-        if ($rtk['heading_atn_dis']) { $t.RtkHeadingAtnDis = [double]$rtk['heading_atn_dis'].Value }
-        if ($rtk['heading_multi']) { $t.RtkHeadingMulti = [int]$rtk['heading_multi'].Value }
-        if ($rtk['heading_obs']) { $t.RtkHeadingObs = [int]$rtk['heading_obs'].Value }
-        if ($rtk['pre4_timestamp']) { $t.RtkPre4Timestamp = [double]$rtk['pre4_timestamp'].Value }
-        if ($rtk['rtk_version']) { $t.RtkVersion = [string]$rtk['rtk_version'].Value }
-        if ($rtk['sat_num']) { $t.RtkSatNum = [int]$rtk['sat_num'].Value }
-        if ($rtk['timestamp']) { $t.RtkTimestamp = [double]$rtk['timestamp'].Value }
-    }
-    $root = $DeviceMsg.PSObject.Properties
-    if ($root['combined_odom_confidence']) { $t.OdomConfidence = [double]$root['combined_odom_confidence'].Value }
-    if ($root['rtcm_age']) { $t.RtcmAge = [double]$root['rtcm_age'].Value }
-    if ($root['rtcm_info']) { $t.RtcmInfo = $root['rtcm_info'].Value }
-    if ($DeviceMsg.rtk_base_data) {
-        $rbd = $DeviceMsg.rtk_base_data.PSObject.Properties
-        if ($rbd['rover']) {
-            $roverProp = $rbd['rover'].Value.PSObject.Properties['heading']
-            if ($roverProp) { $t.RoverHeading = [string]$roverProp.Value }
-        }
-        if ($rbd['base']) {
-            $baseProp = $rbd['base'].Value.PSObject.Properties['gngga']
-            if ($baseProp) { $t.BaseGngga = [string]$baseProp.Value }
-        }
-    }
-
-    # Running status
-    if ($DeviceMsg.RunningStatusMSG) {
-        $t.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
-        $t.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data)
-        $run = $DeviceMsg.RunningStatusMSG.PSObject.Properties
-        if ($run['chute_steering_engine_info']) { $t.ChuteSteeringEngineInfo = [int]$run['chute_steering_engine_info'].Value }
-        if ($run['chute_steering_run_status']) { $t.ChuteSteeringRunStatus = [int]$run['chute_steering_run_status'].Value }
-        if ($run['head_gyro_pitch']) { $t.HeadGyroPitch = [double]$run['head_gyro_pitch'].Value }
-        if ($run['head_gyro_roll']) { $t.HeadGyroRoll = [double]$run['head_gyro_roll'].Value }
-        if ($run['push_pod_status']) { $t.PushPodStatus = [int]$run['push_pod_status'].Value }
-        if ($run['push_rod_place']) { $t.PushRodPlace = [int]$run['push_rod_place'].Value }
-        if ($run['snow_pipe_run_status']) { $t.SnowPipeRunStatus = [int]$run['snow_pipe_run_status'].Value }
-        if ($run['snow_roller_motor']) { $t.SnowRollerMotor = [int]$run['snow_roller_motor'].Value }
-        if ($run['elec_navigation_front_right_sensor']) { $t.ElecNavigationFrontRightSensor = [int]$run['elec_navigation_front_right_sensor'].Value }
-        if ($run['elec_navigation_rear_right_sensor']) { $t.ElecNavigationRearRightSensor = [int]$run['elec_navigation_rear_right_sensor'].Value }
-    }
-
-    # State
-    if ($DeviceMsg.StateMSG) {
-        $t.WorkingState = [int]($DeviceMsg.StateMSG.working_state)
-        $t.ChargingStatus = [int]($DeviceMsg.StateMSG.charging_status)
-        $t.ErrorCode = [int]($DeviceMsg.StateMSG.error_code)
-        $t.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
-        $t.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
-        $t.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
-        $state = $DeviceMsg.StateMSG.PSObject.Properties
-        if ($state['adjustangle_status']) { $t.AdjustAngleStatus = [int]$state['adjustangle_status'].Value }
-        if ($state['auto_draw_waiting_state']) { $t.AutoDrawWaitingState = [int]$state['auto_draw_waiting_state'].Value }
-        if ($state['en_state_led']) { $t.EnStateLed = [int]$state['en_state_led'].Value }
-        if ($state['en_warn_led']) { $t.EnWarnLed = [int]$state['en_warn_led'].Value }
-        if ($state['on_going_to_start_point']) { $t.OnGoingToStartPoint = ([int]$state['on_going_to_start_point'].Value -gt 0) }
-        if ($state['on_mul_points']) { $t.OnMulPoints = ([int]$state['on_mul_points'].Value -gt 0) }
-        if ($state['robot_follow_state']) { $t.RobotFollowState = [int]$state['robot_follow_state'].Value }
-        if ($state['schedule_cancel']) { $t.ScheduleCancel = [int]$state['schedule_cancel'].Value }
-        if ($state['vision_auto_draw_state']) { $t.VisionAutoDrawState = [int]$state['vision_auto_draw_state'].Value }
-    }
-
-    # Ultrasonic sensors
-    if ($DeviceMsg.ultrasonic_msg) {
-        $t.UltrasonicLeftFront = [int]($DeviceMsg.ultrasonic_msg.lf_dis)
-        $t.UltrasonicMiddle = [int]($DeviceMsg.ultrasonic_msg.mt_dis)
-        $t.UltrasonicRightFront = [int]($DeviceMsg.ultrasonic_msg.rf_dis)
-    }
-
-    # Wireless charging
-    if ($DeviceMsg.wireless_recharge) {
-        $t.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
-        $t.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
-        $t.WirelessChargeCurrent = [double]($DeviceMsg.wireless_recharge.output_current)
-        $t.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
-    }
-
-    # LED (led, LedInfoMSG, HeadMsg.head_led_brightness)
-    if ($root['led']) { $t.LedRegister = [string]$root['led'].Value }
-    if ($root['LedInfoMSG']) { $t.LedInfo = $root['LedInfoMSG'].Value }
-    if ($DeviceMsg.HeadMsg) {
-        $headProp = $DeviceMsg.HeadMsg.PSObject.Properties['head_led_brightness']
-        if ($headProp) { $t.HeadLedBrightness = [int]$headProp.Value }
-    }
-
-    # Electric (EletricMSG)
-    if ($root['EletricMSG']) {
-        $elec = $root['EletricMSG'].Value.PSObject.Properties
-        if ($elec['brushless_motor_current']) { $t.BrushlessMotorCurrent = [double]$elec['brushless_motor_current'].Value }
-        if ($elec['ntc_temperature']) { $t.NtcTemperature = [double]$elec['ntc_temperature'].Value }
-        if ($elec['push_pod_current']) { $t.PushPodCurrent = [double]$elec['push_pod_current'].Value }
-    }
-
-    # Misc (base_status, switches, system_info, DebugMsg)
-    if ($root['base_status']) { $t.BaseStatus = $root['base_status'].Value }
-    if ($root['green_grass_update_switch']) { $t.GreenGrassUpdateSwitch = [int]$root['green_grass_update_switch'].Value }
-    if ($root['ipcamera_ota_switch']) { $t.IpcameraOtaSwitch = [int]$root['ipcamera_ota_switch'].Value }
-    if ($root['system_info']) { $t.SystemInfo = $root['system_info'].Value }
-    if ($root['DebugMsg']) { $t.DebugMsg = $root['DebugMsg'].Value }
-
-    # Device message timestamp (root)
-    if ($root['timestamp']) { $t.DeviceTimestamp = [double]$root['timestamp'].Value }
 
     # GPS — parse GNGGA NMEA sentence from rtk_base_data.rover.gngga
     if ($DeviceMsg.rtk_base_data) {
@@ -272,44 +289,21 @@ function ConvertTo-YarboRobot {
     $r.LastUpdated = [datetime]::UtcNow
     $r.RawMessage = $DeviceMsg
 
+    Set-YarboCommonFields -DeviceMsg $DeviceMsg -Target $r
+
     # Head (HeadMsg, HeadSerialMsg)
     if ($DeviceMsg.HeadMsg) { $r.HeadType = [int]($DeviceMsg.HeadMsg.head_type) }
     if ($DeviceMsg.HeadSerialMsg) { $r.HeadSerialNumber = $DeviceMsg.HeadSerialMsg.head_sn }
-
-    # Battery (BatteryMSG)
-    if ($DeviceMsg.BatteryMSG) {
-        $r.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
-        $r.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
-        $r.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
-        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
-        $cur = $DeviceMsg.BatteryMSG.PSObject.Properties['current']; if ($cur) { $r.BatteryCurrent = [double]$cur.Value }
-        $vol = $DeviceMsg.BatteryMSG.PSObject.Properties['voltage']; if ($vol) { $r.BatteryVoltage = [double]$vol.Value }
-    }
 
     # Body (BodyMsg)
     if ($DeviceMsg.BodyMsg -and $DeviceMsg.BodyMsg.PSObject.Properties["recharge_state"]) {
         $r.RechargeState = [int]($DeviceMsg.BodyMsg.recharge_state)
     }
 
-    # State (StateMSG)
+    # State (StateMSG) - Robot-specific fields
     if ($DeviceMsg.StateMSG) {
-        $r.WorkingState = [int]($DeviceMsg.StateMSG.working_state)
-        $r.ChargingStatus = [int]($DeviceMsg.StateMSG.charging_status)
-        $r.ErrorCode = [int]($DeviceMsg.StateMSG.error_code)
         $r.MachineController = [int]($DeviceMsg.StateMSG.machine_controller)
-        $r.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
-        $r.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
-        $r.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
-        if ($DeviceMsg.StateMSG.PSObject.Properties["adjustangle_status"]) { $r.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["auto_draw_waiting_state"]) { $r.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
         if ($DeviceMsg.StateMSG.PSObject.Properties["car_controller"]) { $r.CarController = [bool]($DeviceMsg.StateMSG.car_controller) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["en_state_led"]) { $r.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["en_warn_led"]) { $r.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["on_going_to_start_point"]) { $r.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["on_mul_points"]) { $r.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["robot_follow_state"]) { $r.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["schedule_cancel"]) { $r.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["vision_auto_draw_state"]) { $r.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
     }
 
     # Position
@@ -318,71 +312,6 @@ function ConvertTo-YarboRobot {
         $r.OdometryY = [double]($DeviceMsg.CombinedOdom.y)
         $r.OdometryPhi = [double]($DeviceMsg.CombinedOdom.phi)
     }
-    if ($DeviceMsg.RTKMSG) {
-        $r.Heading = [double]($DeviceMsg.RTKMSG.heading)
-        $r.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        $rtk = $DeviceMsg.RTKMSG.PSObject.Properties
-        if ($rtk['heading_status']) { $r.RtkHeadingStatus = [int]$rtk['heading_status'].Value }
-        if ($rtk['heading_dop']) { $r.RtkHeadingDop = [double]$rtk['heading_dop'].Value }
-        if ($rtk['gga_atn_dis']) { $r.RtkGgaAtnDis = [double]$rtk['gga_atn_dis'].Value }
-        if ($rtk['heading_atn_dis']) { $r.RtkHeadingAtnDis = [double]$rtk['heading_atn_dis'].Value }
-        if ($rtk['heading_multi']) { $r.RtkHeadingMulti = [int]$rtk['heading_multi'].Value }
-        if ($rtk['heading_obs']) { $r.RtkHeadingObs = [int]$rtk['heading_obs'].Value }
-        if ($rtk['pre4_timestamp']) { $r.RtkPre4Timestamp = [double]$rtk['pre4_timestamp'].Value }
-        if ($rtk['rtk_version']) { $r.RtkVersion = [string]$rtk['rtk_version'].Value }
-        if ($rtk['sat_num']) { $r.RtkSatNum = [int]$rtk['sat_num'].Value }
-        if ($rtk['timestamp']) { $r.RtkTimestamp = [double]$rtk['timestamp'].Value }
-    }
-    $rootR = $DeviceMsg.PSObject.Properties
-    if ($rootR['combined_odom_confidence']) { $r.OdomConfidence = [double]$rootR['combined_odom_confidence'].Value }
-    if ($rootR['rtcm_age']) { $r.RtcmAge = [double]$rootR['rtcm_age'].Value }
-    if ($rootR['rtcm_info']) { $r.RtcmInfo = $rootR['rtcm_info'].Value }
-    if ($DeviceMsg.rtk_base_data) {
-        $rbdR = $DeviceMsg.rtk_base_data.PSObject.Properties
-        if ($rbdR['rover']) {
-            $roverPropR = $rbdR['rover'].Value.PSObject.Properties['heading']
-            if ($roverPropR) { $r.RoverHeading = [string]$roverPropR.Value }
-        }
-        if ($rbdR['base']) {
-            $basePropR = $rbdR['base'].Value.PSObject.Properties['gngga']
-            if ($basePropR) { $r.BaseGngga = [string]$basePropR.Value }
-        }
-    }
-
-    # Hardware (RunningStatusMSG, led, wireless_recharge)
-    if ($DeviceMsg.RunningStatusMSG) {
-        $r.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["rain_sensor_data"]) { $r.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_engine_info"]) { $r.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_run_status"]) { $r.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_pitch"]) { $r.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_roll"]) { $r.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_pod_status"]) { $r.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_rod_place"]) { $r.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_pipe_run_status"]) { $r.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_roller_motor"]) { $r.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_front_right_sensor"]) { $r.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_rear_right_sensor"]) { $r.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
-    }
-    if ($DeviceMsg.PSObject.Properties["led"]) { $r.LedRegister = [string]($DeviceMsg.led) }
-    if ($DeviceMsg.PSObject.Properties["LedInfoMSG"]) { $r.LedInfo = $DeviceMsg.LedInfoMSG }
-    if ($DeviceMsg.HeadMsg -and $DeviceMsg.HeadMsg.PSObject.Properties["head_led_brightness"]) { $r.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
-    if ($DeviceMsg.wireless_recharge) {
-        $r.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
-        $r.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
-        $r.WirelessChargeCurrent = [double]($DeviceMsg.wireless_recharge.output_current)
-        $r.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
-    }
-
-    # Ultrasonic (ultrasonic_msg)
-    if ($DeviceMsg.ultrasonic_msg) {
-        $r.UltrasonicLeftFront = [int]($DeviceMsg.ultrasonic_msg.lf_dis)
-        $r.UltrasonicMiddle = [int]($DeviceMsg.ultrasonic_msg.mt_dis)
-        $r.UltrasonicRightFront = [int]($DeviceMsg.ultrasonic_msg.rf_dis)
-    }
-
-    # Device message timestamp (root)
-    if ($DeviceMsg.PSObject.Properties["timestamp"]) { $r.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
 
     # Network (route_priority)
     if ($DeviceMsg.route_priority) {
@@ -390,23 +319,13 @@ function ConvertTo-YarboRobot {
         $DeviceMsg.route_priority.PSObject.Properties | ForEach-Object { $r.RoutePriority[$_.Name] = $_.Value }
     }
 
-    # Misc / switches / system / debug
-    if ($DeviceMsg.PSObject.Properties["base_status"]) { $r.BaseStatus = $DeviceMsg.base_status }
+    # Misc / switches / system / debug - Robot-specific fields
     if ($DeviceMsg.PSObject.Properties["bds"]) { $r.Bds = $DeviceMsg.bds }
     if ($DeviceMsg.PSObject.Properties["bs"]) { $r.Bs = $DeviceMsg.bs }
-    if ($DeviceMsg.PSObject.Properties["green_grass_update_switch"]) { $r.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
-    if ($DeviceMsg.PSObject.Properties["ipcamera_ota_switch"]) { $r.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
     if ($DeviceMsg.PSObject.Properties["ms"]) { $r.Ms = $DeviceMsg.ms }
     if ($DeviceMsg.PSObject.Properties["s"]) { $r.S = $DeviceMsg.s }
     if ($DeviceMsg.PSObject.Properties["sbs"]) { $r.Sbs = $DeviceMsg.sbs }
     if ($DeviceMsg.PSObject.Properties["tms"]) { $r.Tms = $DeviceMsg.tms }
-    if ($DeviceMsg.PSObject.Properties["system_info"]) { $r.SystemInfo = $DeviceMsg.system_info }
-    if ($DeviceMsg.PSObject.Properties["DebugMsg"]) { $r.DebugMsg = $DeviceMsg.DebugMsg }
-    if ($DeviceMsg.PSObject.Properties["EletricMSG"]) {
-        if ($DeviceMsg.EletricMSG.PSObject.Properties["brushless_motor_current"]) { $r.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
-        if ($DeviceMsg.EletricMSG.PSObject.Properties["ntc_temperature"]) { $r.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
-        if ($DeviceMsg.EletricMSG.PSObject.Properties["push_pod_current"]) { $r.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
-    }
 
     return $r
 }

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -99,9 +99,9 @@ function ConvertTo-YarboTelemetry {
         $t.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
         $t.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $t.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
-        if ($DeviceMsg.BatteryMSG.PSObject.Properties["timestamp"]) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
-        if ($DeviceMsg.BatteryMSG.PSObject.Properties["current"]) { $t.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
-        if ($DeviceMsg.BatteryMSG.PSObject.Properties["voltage"]) { $t.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
+        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        $cur = $DeviceMsg.BatteryMSG.PSObject.Properties['current']; if ($cur) { $t.BatteryCurrent = [double]$cur.Value }
+        $vol = $DeviceMsg.BatteryMSG.PSObject.Properties['voltage']; if ($vol) { $t.BatteryVoltage = [double]$vol.Value }
     }
 
     # Body (BodyMsg)
@@ -118,40 +118,50 @@ function ConvertTo-YarboTelemetry {
 
     if ($DeviceMsg.RTKMSG) {
         $t.Heading = [double]($DeviceMsg.RTKMSG.heading)
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_status"]) { $t.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $t.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_dop"]) { $t.RtkDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["gga_atn_dis"]) { $t.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_atn_dis"]) { $t.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_multi"]) { $t.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_obs"]) { $t.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["pre4_timestamp"]) { $t.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["rtk_version"]) { $t.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["sat_num"]) { $t.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["timestamp"]) { $t.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
+        $rtk = $DeviceMsg.RTKMSG.PSObject.Properties
+        if ($rtk['heading_status']) { $t.RtkHeadingStatus = [int]$rtk['heading_status'].Value }
+        if ($rtk['heading_dop']) { $t.RtkDop = [double]$rtk['heading_dop'].Value }
+        if ($rtk['gga_atn_dis']) { $t.RtkGgaAtnDis = [double]$rtk['gga_atn_dis'].Value }
+        if ($rtk['heading_atn_dis']) { $t.RtkHeadingAtnDis = [double]$rtk['heading_atn_dis'].Value }
+        if ($rtk['heading_multi']) { $t.RtkHeadingMulti = [int]$rtk['heading_multi'].Value }
+        if ($rtk['heading_obs']) { $t.RtkHeadingObs = [int]$rtk['heading_obs'].Value }
+        if ($rtk['pre4_timestamp']) { $t.RtkPre4Timestamp = [double]$rtk['pre4_timestamp'].Value }
+        if ($rtk['rtk_version']) { $t.RtkVersion = [string]$rtk['rtk_version'].Value }
+        if ($rtk['sat_num']) { $t.RtkSatNum = [int]$rtk['sat_num'].Value }
+        if ($rtk['timestamp']) { $t.RtkTimestamp = [double]$rtk['timestamp'].Value }
     }
-    if ($DeviceMsg.PSObject.Properties["combined_odom_confidence"]) {
-        $t.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
+    $root = $DeviceMsg.PSObject.Properties
+    if ($root['combined_odom_confidence']) { $t.OdomConfidence = [double]$root['combined_odom_confidence'].Value }
+    if ($root['rtcm_age']) { $t.RtcmAge = [double]$root['rtcm_age'].Value }
+    if ($root['rtcm_info']) { $t.RtcmInfo = $root['rtcm_info'].Value }
+    if ($DeviceMsg.rtk_base_data) {
+        $rbd = $DeviceMsg.rtk_base_data.PSObject.Properties
+        if ($rbd['rover']) {
+            $roverProp = $rbd['rover'].Value.PSObject.Properties['heading']
+            if ($roverProp) { $t.RoverHeading = [string]$roverProp.Value }
+        }
+        if ($rbd['base']) {
+            $baseProp = $rbd['base'].Value.PSObject.Properties['gngga']
+            if ($baseProp) { $t.BaseGngga = [string]$baseProp.Value }
+        }
     }
-    if ($DeviceMsg.PSObject.Properties["rtcm_age"]) { $t.RtcmAge = [double]($DeviceMsg.rtcm_age) }
-    if ($DeviceMsg.PSObject.Properties["rtcm_info"]) { $t.RtcmInfo = $DeviceMsg.rtcm_info }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["rover"] -and $DeviceMsg.rtk_base_data.rover.PSObject.Properties["heading"]) { $t.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["base"] -and $DeviceMsg.rtk_base_data.base.PSObject.Properties["gngga"]) { $t.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
 
     # Running status
     if ($DeviceMsg.RunningStatusMSG) {
         $t.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
         $t.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data)
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_engine_info"]) { $t.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["chute_steering_run_status"]) { $t.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_pitch"]) { $t.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["head_gyro_roll"]) { $t.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_pod_status"]) { $t.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["push_rod_place"]) { $t.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_pipe_run_status"]) { $t.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["snow_roller_motor"]) { $t.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_front_right_sensor"]) { $t.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
-        if ($DeviceMsg.RunningStatusMSG.PSObject.Properties["elec_navigation_rear_right_sensor"]) { $t.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
+        $run = $DeviceMsg.RunningStatusMSG.PSObject.Properties
+        if ($run['chute_steering_engine_info']) { $t.ChuteSteeringEngineInfo = [int]$run['chute_steering_engine_info'].Value }
+        if ($run['chute_steering_run_status']) { $t.ChuteSteeringRunStatus = [int]$run['chute_steering_run_status'].Value }
+        if ($run['head_gyro_pitch']) { $t.HeadGyroPitch = [double]$run['head_gyro_pitch'].Value }
+        if ($run['head_gyro_roll']) { $t.HeadGyroRoll = [double]$run['head_gyro_roll'].Value }
+        if ($run['push_pod_status']) { $t.PushPodStatus = [int]$run['push_pod_status'].Value }
+        if ($run['push_rod_place']) { $t.PushRodPlace = [int]$run['push_rod_place'].Value }
+        if ($run['snow_pipe_run_status']) { $t.SnowPipeRunStatus = [int]$run['snow_pipe_run_status'].Value }
+        if ($run['snow_roller_motor']) { $t.SnowRollerMotor = [int]$run['snow_roller_motor'].Value }
+        if ($run['elec_navigation_front_right_sensor']) { $t.ElecNavigationFrontRightSensor = [int]$run['elec_navigation_front_right_sensor'].Value }
+        if ($run['elec_navigation_rear_right_sensor']) { $t.ElecNavigationRearRightSensor = [int]$run['elec_navigation_rear_right_sensor'].Value }
     }
 
     # State
@@ -162,15 +172,16 @@ function ConvertTo-YarboTelemetry {
         $t.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
         $t.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
         $t.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
-        if ($DeviceMsg.StateMSG.PSObject.Properties["adjustangle_status"]) { $t.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["auto_draw_waiting_state"]) { $t.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["en_state_led"]) { $t.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["en_warn_led"]) { $t.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["on_going_to_start_point"]) { $t.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["on_mul_points"]) { $t.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["robot_follow_state"]) { $t.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["schedule_cancel"]) { $t.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
-        if ($DeviceMsg.StateMSG.PSObject.Properties["vision_auto_draw_state"]) { $t.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
+        $state = $DeviceMsg.StateMSG.PSObject.Properties
+        if ($state['adjustangle_status']) { $t.AdjustAngleStatus = [int]$state['adjustangle_status'].Value }
+        if ($state['auto_draw_waiting_state']) { $t.AutoDrawWaitingState = [int]$state['auto_draw_waiting_state'].Value }
+        if ($state['en_state_led']) { $t.EnStateLed = [int]$state['en_state_led'].Value }
+        if ($state['en_warn_led']) { $t.EnWarnLed = [int]$state['en_warn_led'].Value }
+        if ($state['on_going_to_start_point']) { $t.OnGoingToStartPoint = ([int]$state['on_going_to_start_point'].Value -gt 0) }
+        if ($state['on_mul_points']) { $t.OnMulPoints = ([int]$state['on_mul_points'].Value -gt 0) }
+        if ($state['robot_follow_state']) { $t.RobotFollowState = [int]$state['robot_follow_state'].Value }
+        if ($state['schedule_cancel']) { $t.ScheduleCancel = [int]$state['schedule_cancel'].Value }
+        if ($state['vision_auto_draw_state']) { $t.VisionAutoDrawState = [int]$state['vision_auto_draw_state'].Value }
     }
 
     # Ultrasonic sensors
@@ -189,36 +200,46 @@ function ConvertTo-YarboTelemetry {
     }
 
     # LED (led, LedInfoMSG, HeadMsg.head_led_brightness)
-    if ($DeviceMsg.PSObject.Properties["led"]) { $t.LedRegister = [string]($DeviceMsg.led) }
-    if ($DeviceMsg.PSObject.Properties["LedInfoMSG"]) { $t.LedInfo = $DeviceMsg.LedInfoMSG }
-    if ($DeviceMsg.HeadMsg -and $DeviceMsg.HeadMsg.PSObject.Properties["head_led_brightness"]) { $t.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
+    if ($root['led']) { $t.LedRegister = [string]$root['led'].Value }
+    if ($root['LedInfoMSG']) { $t.LedInfo = $root['LedInfoMSG'].Value }
+    if ($DeviceMsg.HeadMsg) {
+        $headProp = $DeviceMsg.HeadMsg.PSObject.Properties['head_led_brightness']
+        if ($headProp) { $t.HeadLedBrightness = [int]$headProp.Value }
+    }
 
     # Electric (EletricMSG)
-    if ($DeviceMsg.PSObject.Properties["EletricMSG"]) {
-        if ($DeviceMsg.EletricMSG.PSObject.Properties["brushless_motor_current"]) { $t.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
-        if ($DeviceMsg.EletricMSG.PSObject.Properties["ntc_temperature"]) { $t.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
-        if ($DeviceMsg.EletricMSG.PSObject.Properties["push_pod_current"]) { $t.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
+    if ($root['EletricMSG']) {
+        $elec = $root['EletricMSG'].Value.PSObject.Properties
+        if ($elec['brushless_motor_current']) { $t.BrushlessMotorCurrent = [double]$elec['brushless_motor_current'].Value }
+        if ($elec['ntc_temperature']) { $t.NtcTemperature = [double]$elec['ntc_temperature'].Value }
+        if ($elec['push_pod_current']) { $t.PushPodCurrent = [double]$elec['push_pod_current'].Value }
     }
 
     # Misc (base_status, switches, system_info, DebugMsg)
-    if ($DeviceMsg.PSObject.Properties["base_status"]) { $t.BaseStatus = $DeviceMsg.base_status }
-    if ($DeviceMsg.PSObject.Properties["green_grass_update_switch"]) { $t.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
-    if ($DeviceMsg.PSObject.Properties["ipcamera_ota_switch"]) { $t.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
-    if ($DeviceMsg.PSObject.Properties["system_info"]) { $t.SystemInfo = $DeviceMsg.system_info }
-    if ($DeviceMsg.PSObject.Properties["DebugMsg"]) { $t.DebugMsg = $DeviceMsg.DebugMsg }
+    if ($root['base_status']) { $t.BaseStatus = $root['base_status'].Value }
+    if ($root['green_grass_update_switch']) { $t.GreenGrassUpdateSwitch = [int]$root['green_grass_update_switch'].Value }
+    if ($root['ipcamera_ota_switch']) { $t.IpcameraOtaSwitch = [int]$root['ipcamera_ota_switch'].Value }
+    if ($root['system_info']) { $t.SystemInfo = $root['system_info'].Value }
+    if ($root['DebugMsg']) { $t.DebugMsg = $root['DebugMsg'].Value }
 
     # Device message timestamp (root)
-    if ($DeviceMsg.PSObject.Properties["timestamp"]) { $t.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
+    if ($root['timestamp']) { $t.DeviceTimestamp = [double]$root['timestamp'].Value }
 
     # GPS — parse GNGGA NMEA sentence from rtk_base_data.rover.gngga
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $DeviceMsg.rtk_base_data.rover.gngga) {
-        $gnggaRaw = [string]$DeviceMsg.rtk_base_data.rover.gngga
-        $t.GnggaRaw = $gnggaRaw
-        $gps = ConvertFrom-GnggaSentence -Sentence $gnggaRaw
-        $t.FixQuality = $gps.FixQuality
-        $t.Latitude = $gps.Latitude
-        $t.Longitude = $gps.Longitude
-        $t.Altitude = $gps.Altitude
+    if ($DeviceMsg.rtk_base_data) {
+        $rbdGps = $DeviceMsg.rtk_base_data.PSObject.Properties['rover']
+        if ($rbdGps) {
+            $gnggaProp = $rbdGps.Value.PSObject.Properties['gngga']
+            if ($gnggaProp) {
+                $gnggaRaw = [string]$gnggaProp.Value
+                $t.GnggaRaw = $gnggaRaw
+                $gps = ConvertFrom-GnggaSentence -Sentence $gnggaRaw
+                $t.FixQuality = $gps.FixQuality
+                $t.Latitude = $gps.Latitude
+                $t.Longitude = $gps.Longitude
+                $t.Altitude = $gps.Altitude
+            }
+        }
     }
 
     return $t
@@ -260,9 +281,9 @@ function ConvertTo-YarboRobot {
         $r.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
         $r.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $r.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
-        if ($DeviceMsg.BatteryMSG.PSObject.Properties["timestamp"]) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
-        if ($DeviceMsg.BatteryMSG.PSObject.Properties["current"]) { $r.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
-        if ($DeviceMsg.BatteryMSG.PSObject.Properties["voltage"]) { $r.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
+        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        $cur = $DeviceMsg.BatteryMSG.PSObject.Properties['current']; if ($cur) { $r.BatteryCurrent = [double]$cur.Value }
+        $vol = $DeviceMsg.BatteryMSG.PSObject.Properties['voltage']; if ($vol) { $r.BatteryVoltage = [double]$vol.Value }
     }
 
     # Body (BodyMsg)
@@ -299,25 +320,34 @@ function ConvertTo-YarboRobot {
     }
     if ($DeviceMsg.RTKMSG) {
         $r.Heading = [double]($DeviceMsg.RTKMSG.heading)
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_status"]) { $r.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $r.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_dop"]) { $r.RtkHeadingDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["gga_atn_dis"]) { $r.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_atn_dis"]) { $r.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_multi"]) { $r.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["heading_obs"]) { $r.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["pre4_timestamp"]) { $r.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["rtk_version"]) { $r.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["sat_num"]) { $r.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
-        if ($DeviceMsg.RTKMSG.PSObject.Properties["timestamp"]) { $r.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
+        $rtk = $DeviceMsg.RTKMSG.PSObject.Properties
+        if ($rtk['heading_status']) { $r.RtkHeadingStatus = [int]$rtk['heading_status'].Value }
+        if ($rtk['heading_dop']) { $r.RtkHeadingDop = [double]$rtk['heading_dop'].Value }
+        if ($rtk['gga_atn_dis']) { $r.RtkGgaAtnDis = [double]$rtk['gga_atn_dis'].Value }
+        if ($rtk['heading_atn_dis']) { $r.RtkHeadingAtnDis = [double]$rtk['heading_atn_dis'].Value }
+        if ($rtk['heading_multi']) { $r.RtkHeadingMulti = [int]$rtk['heading_multi'].Value }
+        if ($rtk['heading_obs']) { $r.RtkHeadingObs = [int]$rtk['heading_obs'].Value }
+        if ($rtk['pre4_timestamp']) { $r.RtkPre4Timestamp = [double]$rtk['pre4_timestamp'].Value }
+        if ($rtk['rtk_version']) { $r.RtkVersion = [string]$rtk['rtk_version'].Value }
+        if ($rtk['sat_num']) { $r.RtkSatNum = [int]$rtk['sat_num'].Value }
+        if ($rtk['timestamp']) { $r.RtkTimestamp = [double]$rtk['timestamp'].Value }
     }
-    if ($DeviceMsg.PSObject.Properties["combined_odom_confidence"]) {
-        $r.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
+    $rootR = $DeviceMsg.PSObject.Properties
+    if ($rootR['combined_odom_confidence']) { $r.OdomConfidence = [double]$rootR['combined_odom_confidence'].Value }
+    if ($rootR['rtcm_age']) { $r.RtcmAge = [double]$rootR['rtcm_age'].Value }
+    if ($rootR['rtcm_info']) { $r.RtcmInfo = $rootR['rtcm_info'].Value }
+    if ($DeviceMsg.rtk_base_data) {
+        $rbdR = $DeviceMsg.rtk_base_data.PSObject.Properties
+        if ($rbdR['rover']) {
+            $roverPropR = $rbdR['rover'].Value.PSObject.Properties['heading']
+            if ($roverPropR) { $r.RoverHeading = [string]$roverPropR.Value }
+        }
+        if ($rbdR['base']) {
+            $basePropR = $rbdR['base'].Value.PSObject.Properties['gngga']
+            if ($basePropR) { $r.BaseGngga = [string]$basePropR.Value }
+        }
     }
-    if ($DeviceMsg.PSObject.Properties["rtcm_age"]) { $r.RtcmAge = [double]($DeviceMsg.rtcm_age) }
-    if ($DeviceMsg.PSObject.Properties["rtcm_info"]) { $r.RtcmInfo = $DeviceMsg.rtcm_info }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["rover"] -and $DeviceMsg.rtk_base_data.rover.PSObject.Properties["heading"]) { $r.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
-    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.PSObject.Properties["base"] -and $DeviceMsg.rtk_base_data.base.PSObject.Properties["gngga"]) { $r.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
 
     # Hardware (RunningStatusMSG, led, wireless_recharge)
     if ($DeviceMsg.RunningStatusMSG) {

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -100,6 +100,8 @@ function ConvertTo-YarboTelemetry {
         $t.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $t.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
         if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        if ($null -ne $DeviceMsg.BatteryMSG.current) { $t.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
+        if ($null -ne $DeviceMsg.BatteryMSG.voltage) { $t.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
     }
 
     # Body (BodyMsg)
@@ -119,16 +121,37 @@ function ConvertTo-YarboTelemetry {
         if ($null -ne $DeviceMsg.RTKMSG.heading_status) { $t.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $t.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
         if ($null -ne $DeviceMsg.RTKMSG.heading_dop) { $t.RtkDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
+        if ($null -ne $DeviceMsg.RTKMSG.gga_atn_dis) { $t.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_atn_dis) { $t.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_multi) { $t.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_obs) { $t.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
+        if ($null -ne $DeviceMsg.RTKMSG.pre4_timestamp) { $t.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
+        if ($null -ne $DeviceMsg.RTKMSG.rtk_version) { $t.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
+        if ($null -ne $DeviceMsg.RTKMSG.sat_num) { $t.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
+        if ($null -ne $DeviceMsg.RTKMSG.timestamp) { $t.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
     }
-
     if ($null -ne $DeviceMsg.combined_odom_confidence) {
         $t.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
     }
+    if ($null -ne $DeviceMsg.rtcm_age) { $t.RtcmAge = [double]($DeviceMsg.rtcm_age) }
+    if ($null -ne $DeviceMsg.rtcm_info) { $t.RtcmInfo = $DeviceMsg.rtcm_info }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $null -ne $DeviceMsg.rtk_base_data.rover.heading) { $t.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.base -and $null -ne $DeviceMsg.rtk_base_data.base.gngga) { $t.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
 
     # Running status
     if ($DeviceMsg.RunningStatusMSG) {
         $t.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
         $t.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data)
+        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_engine_info) { $t.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_run_status) { $t.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_pitch) { $t.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_roll) { $t.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.push_pod_status) { $t.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.push_rod_place) { $t.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_pipe_run_status) { $t.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_roller_motor) { $t.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) { $t.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) { $t.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
     }
 
     # State
@@ -139,6 +162,15 @@ function ConvertTo-YarboTelemetry {
         $t.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
         $t.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
         $t.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
+        if ($null -ne $DeviceMsg.StateMSG.adjustangle_status) { $t.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
+        if ($null -ne $DeviceMsg.StateMSG.auto_draw_waiting_state) { $t.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
+        if ($null -ne $DeviceMsg.StateMSG.en_state_led) { $t.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
+        if ($null -ne $DeviceMsg.StateMSG.en_warn_led) { $t.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
+        if ($null -ne $DeviceMsg.StateMSG.on_going_to_start_point) { $t.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
+        if ($null -ne $DeviceMsg.StateMSG.on_mul_points) { $t.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
+        if ($null -ne $DeviceMsg.StateMSG.robot_follow_state) { $t.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
+        if ($null -ne $DeviceMsg.StateMSG.schedule_cancel) { $t.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
+        if ($null -ne $DeviceMsg.StateMSG.vision_auto_draw_state) { $t.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
     }
 
     # Ultrasonic sensors
@@ -156,8 +188,24 @@ function ConvertTo-YarboTelemetry {
         $t.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
     }
 
-    # LED (led)
+    # LED (led, LedInfoMSG, HeadMsg.head_led_brightness)
     if ($null -ne $DeviceMsg.led) { $t.LedRegister = [string]($DeviceMsg.led) }
+    if ($null -ne $DeviceMsg.LedInfoMSG) { $t.LedInfo = $DeviceMsg.LedInfoMSG }
+    if ($DeviceMsg.HeadMsg -and $null -ne $DeviceMsg.HeadMsg.head_led_brightness) { $t.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
+
+    # Electric (EletricMSG)
+    if ($null -ne $DeviceMsg.EletricMSG) {
+        if ($null -ne $DeviceMsg.EletricMSG.brushless_motor_current) { $t.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
+        if ($null -ne $DeviceMsg.EletricMSG.ntc_temperature) { $t.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
+        if ($null -ne $DeviceMsg.EletricMSG.push_pod_current) { $t.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
+    }
+
+    # Misc (base_status, switches, system_info, DebugMsg)
+    if ($null -ne $DeviceMsg.base_status) { $t.BaseStatus = $DeviceMsg.base_status }
+    if ($null -ne $DeviceMsg.green_grass_update_switch) { $t.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
+    if ($null -ne $DeviceMsg.ipcamera_ota_switch) { $t.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
+    if ($null -ne $DeviceMsg.system_info) { $t.SystemInfo = $DeviceMsg.system_info }
+    if ($null -ne $DeviceMsg.DebugMsg) { $t.DebugMsg = $DeviceMsg.DebugMsg }
 
     # Device message timestamp (root)
     if ($null -ne $DeviceMsg.timestamp) { $t.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
@@ -213,6 +261,8 @@ function ConvertTo-YarboRobot {
         $r.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $r.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
         if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+        if ($null -ne $DeviceMsg.BatteryMSG.current) { $r.BatteryCurrent = [double]($DeviceMsg.BatteryMSG.current) }
+        if ($null -ne $DeviceMsg.BatteryMSG.voltage) { $r.BatteryVoltage = [double]($DeviceMsg.BatteryMSG.voltage) }
     }
 
     # Body (BodyMsg)
@@ -229,6 +279,16 @@ function ConvertTo-YarboRobot {
         $r.IsPlanning = ([int]($DeviceMsg.StateMSG.on_going_planning) -gt 0)
         $r.IsPaused = ([int]($DeviceMsg.StateMSG.planning_paused) -gt 0)
         $r.IsRecharging = ([int]($DeviceMsg.StateMSG.on_going_recharging) -gt 0)
+        if ($null -ne $DeviceMsg.StateMSG.adjustangle_status) { $r.AdjustAngleStatus = [int]($DeviceMsg.StateMSG.adjustangle_status) }
+        if ($null -ne $DeviceMsg.StateMSG.auto_draw_waiting_state) { $r.AutoDrawWaitingState = [int]($DeviceMsg.StateMSG.auto_draw_waiting_state) }
+        if ($null -ne $DeviceMsg.StateMSG.car_controller) { $r.CarController = [bool]($DeviceMsg.StateMSG.car_controller) }
+        if ($null -ne $DeviceMsg.StateMSG.en_state_led) { $r.EnStateLed = [int]($DeviceMsg.StateMSG.en_state_led) }
+        if ($null -ne $DeviceMsg.StateMSG.en_warn_led) { $r.EnWarnLed = [int]($DeviceMsg.StateMSG.en_warn_led) }
+        if ($null -ne $DeviceMsg.StateMSG.on_going_to_start_point) { $r.OnGoingToStartPoint = ([int]($DeviceMsg.StateMSG.on_going_to_start_point) -gt 0) }
+        if ($null -ne $DeviceMsg.StateMSG.on_mul_points) { $r.OnMulPoints = ([int]($DeviceMsg.StateMSG.on_mul_points) -gt 0) }
+        if ($null -ne $DeviceMsg.StateMSG.robot_follow_state) { $r.RobotFollowState = [int]($DeviceMsg.StateMSG.robot_follow_state) }
+        if ($null -ne $DeviceMsg.StateMSG.schedule_cancel) { $r.ScheduleCancel = [int]($DeviceMsg.StateMSG.schedule_cancel) }
+        if ($null -ne $DeviceMsg.StateMSG.vision_auto_draw_state) { $r.VisionAutoDrawState = [int]($DeviceMsg.StateMSG.vision_auto_draw_state) }
     }
 
     # Position
@@ -242,17 +302,41 @@ function ConvertTo-YarboRobot {
         if ($null -ne $DeviceMsg.RTKMSG.heading_status) { $r.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $r.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
         if ($null -ne $DeviceMsg.RTKMSG.heading_dop) { $r.RtkHeadingDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
+        if ($null -ne $DeviceMsg.RTKMSG.gga_atn_dis) { $r.RtkGgaAtnDis = [double]($DeviceMsg.RTKMSG.gga_atn_dis) }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_atn_dis) { $r.RtkHeadingAtnDis = [double]($DeviceMsg.RTKMSG.heading_atn_dis) }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_multi) { $r.RtkHeadingMulti = [int]($DeviceMsg.RTKMSG.heading_multi) }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_obs) { $r.RtkHeadingObs = [int]($DeviceMsg.RTKMSG.heading_obs) }
+        if ($null -ne $DeviceMsg.RTKMSG.pre4_timestamp) { $r.RtkPre4Timestamp = [double]($DeviceMsg.RTKMSG.pre4_timestamp) }
+        if ($null -ne $DeviceMsg.RTKMSG.rtk_version) { $r.RtkVersion = [string]($DeviceMsg.RTKMSG.rtk_version) }
+        if ($null -ne $DeviceMsg.RTKMSG.sat_num) { $r.RtkSatNum = [int]($DeviceMsg.RTKMSG.sat_num) }
+        if ($null -ne $DeviceMsg.RTKMSG.timestamp) { $r.RtkTimestamp = [double]($DeviceMsg.RTKMSG.timestamp) }
     }
     if ($null -ne $DeviceMsg.combined_odom_confidence) {
         $r.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
     }
+    if ($null -ne $DeviceMsg.rtcm_age) { $r.RtcmAge = [double]($DeviceMsg.rtcm_age) }
+    if ($null -ne $DeviceMsg.rtcm_info) { $r.RtcmInfo = $DeviceMsg.rtcm_info }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $null -ne $DeviceMsg.rtk_base_data.rover.heading) { $r.RoverHeading = [string]($DeviceMsg.rtk_base_data.rover.heading) }
+    if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.base -and $null -ne $DeviceMsg.rtk_base_data.base.gngga) { $r.BaseGngga = [string]($DeviceMsg.rtk_base_data.base.gngga) }
 
     # Hardware (RunningStatusMSG, led, wireless_recharge)
     if ($DeviceMsg.RunningStatusMSG) {
         $r.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
         if ($null -ne $DeviceMsg.RunningStatusMSG.rain_sensor_data) { $r.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_engine_info) { $r.ChuteSteeringEngineInfo = [int]($DeviceMsg.RunningStatusMSG.chute_steering_engine_info) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.chute_steering_run_status) { $r.ChuteSteeringRunStatus = [int]($DeviceMsg.RunningStatusMSG.chute_steering_run_status) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_pitch) { $r.HeadGyroPitch = [double]($DeviceMsg.RunningStatusMSG.head_gyro_pitch) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.head_gyro_roll) { $r.HeadGyroRoll = [double]($DeviceMsg.RunningStatusMSG.head_gyro_roll) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.push_pod_status) { $r.PushPodStatus = [int]($DeviceMsg.RunningStatusMSG.push_pod_status) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.push_rod_place) { $r.PushRodPlace = [int]($DeviceMsg.RunningStatusMSG.push_rod_place) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_pipe_run_status) { $r.SnowPipeRunStatus = [int]($DeviceMsg.RunningStatusMSG.snow_pipe_run_status) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.snow_roller_motor) { $r.SnowRollerMotor = [int]($DeviceMsg.RunningStatusMSG.snow_roller_motor) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) { $r.ElecNavigationFrontRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_front_right_sensor) }
+        if ($null -ne $DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) { $r.ElecNavigationRearRightSensor = [int]($DeviceMsg.RunningStatusMSG.elec_navigation_rear_right_sensor) }
     }
     if ($null -ne $DeviceMsg.led) { $r.LedRegister = [string]($DeviceMsg.led) }
+    if ($null -ne $DeviceMsg.LedInfoMSG) { $r.LedInfo = $DeviceMsg.LedInfoMSG }
+    if ($DeviceMsg.HeadMsg -and $null -ne $DeviceMsg.HeadMsg.head_led_brightness) { $r.HeadLedBrightness = [int]($DeviceMsg.HeadMsg.head_led_brightness) }
     if ($DeviceMsg.wireless_recharge) {
         $r.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
         $r.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
@@ -274,6 +358,24 @@ function ConvertTo-YarboRobot {
     if ($DeviceMsg.route_priority) {
         $r.RoutePriority = @{}
         $DeviceMsg.route_priority.PSObject.Properties | ForEach-Object { $r.RoutePriority[$_.Name] = $_.Value }
+    }
+
+    # Misc / switches / system / debug
+    if ($null -ne $DeviceMsg.base_status) { $r.BaseStatus = $DeviceMsg.base_status }
+    if ($null -ne $DeviceMsg.bds) { $r.Bds = $DeviceMsg.bds }
+    if ($null -ne $DeviceMsg.bs) { $r.Bs = $DeviceMsg.bs }
+    if ($null -ne $DeviceMsg.green_grass_update_switch) { $r.GreenGrassUpdateSwitch = [int]($DeviceMsg.green_grass_update_switch) }
+    if ($null -ne $DeviceMsg.ipcamera_ota_switch) { $r.IpcameraOtaSwitch = [int]($DeviceMsg.ipcamera_ota_switch) }
+    if ($null -ne $DeviceMsg.ms) { $r.Ms = $DeviceMsg.ms }
+    if ($null -ne $DeviceMsg.s) { $r.S = $DeviceMsg.s }
+    if ($null -ne $DeviceMsg.sbs) { $r.Sbs = $DeviceMsg.sbs }
+    if ($null -ne $DeviceMsg.tms) { $r.Tms = $DeviceMsg.tms }
+    if ($null -ne $DeviceMsg.system_info) { $r.SystemInfo = $DeviceMsg.system_info }
+    if ($null -ne $DeviceMsg.DebugMsg) { $r.DebugMsg = $DeviceMsg.DebugMsg }
+    if ($null -ne $DeviceMsg.EletricMSG) {
+        if ($null -ne $DeviceMsg.EletricMSG.brushless_motor_current) { $r.BrushlessMotorCurrent = [double]($DeviceMsg.EletricMSG.brushless_motor_current) }
+        if ($null -ne $DeviceMsg.EletricMSG.ntc_temperature) { $r.NtcTemperature = [double]($DeviceMsg.EletricMSG.ntc_temperature) }
+        if ($null -ne $DeviceMsg.EletricMSG.push_pod_current) { $r.PushPodCurrent = [double]($DeviceMsg.EletricMSG.push_pod_current) }
     }
 
     return $r

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -94,11 +94,17 @@ function ConvertTo-YarboTelemetry {
     $t.SerialNumber = $SerialNumber
     $t.RawMessage = $DeviceMsg
 
-    # Battery
+    # Battery (BatteryMSG)
     if ($DeviceMsg.BatteryMSG) {
         $t.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
         $t.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
         $t.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
+        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $t.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
+    }
+
+    # Body (BodyMsg)
+    if ($DeviceMsg.BodyMsg -and $null -ne $DeviceMsg.BodyMsg.recharge_state) {
+        $t.RechargeState = [int]($DeviceMsg.BodyMsg.recharge_state)
     }
 
     # Position
@@ -110,10 +116,9 @@ function ConvertTo-YarboTelemetry {
 
     if ($DeviceMsg.RTKMSG) {
         $t.Heading = [double]($DeviceMsg.RTKMSG.heading)
+        if ($null -ne $DeviceMsg.RTKMSG.heading_status) { $t.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $t.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
-        if ($null -ne $DeviceMsg.RTKMSG.heading_dop) {
-            $t.RtkDop = [double]($DeviceMsg.RTKMSG.heading_dop)
-        }
+        if ($null -ne $DeviceMsg.RTKMSG.heading_dop) { $t.RtkDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
     }
 
     if ($null -ne $DeviceMsg.combined_odom_confidence) {
@@ -151,9 +156,17 @@ function ConvertTo-YarboTelemetry {
         $t.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
     }
 
+    # LED (led)
+    if ($null -ne $DeviceMsg.led) { $t.LedRegister = [string]($DeviceMsg.led) }
+
+    # Device message timestamp (root)
+    if ($null -ne $DeviceMsg.timestamp) { $t.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
+
     # GPS — parse GNGGA NMEA sentence from rtk_base_data.rover.gngga
     if ($DeviceMsg.rtk_base_data -and $DeviceMsg.rtk_base_data.rover -and $DeviceMsg.rtk_base_data.rover.gngga) {
-        $gps = ConvertFrom-GnggaSentence -Sentence ([string]$DeviceMsg.rtk_base_data.rover.gngga)
+        $gnggaRaw = [string]$DeviceMsg.rtk_base_data.rover.gngga
+        $t.GnggaRaw = $gnggaRaw
+        $gps = ConvertFrom-GnggaSentence -Sentence $gnggaRaw
         $t.FixQuality = $gps.FixQuality
         $t.Latitude = $gps.Latitude
         $t.Longitude = $gps.Longitude
@@ -188,18 +201,26 @@ function ConvertTo-YarboRobot {
     $r.Broker = $Broker
     $r.Port = $Port
     $r.LastUpdated = [datetime]::UtcNow
+    $r.RawMessage = $DeviceMsg
 
-    # Head
+    # Head (HeadMsg, HeadSerialMsg)
     if ($DeviceMsg.HeadMsg) { $r.HeadType = [int]($DeviceMsg.HeadMsg.head_type) }
     if ($DeviceMsg.HeadSerialMsg) { $r.HeadSerialNumber = $DeviceMsg.HeadSerialMsg.head_sn }
 
-    # Battery
+    # Battery (BatteryMSG)
     if ($DeviceMsg.BatteryMSG) {
         $r.BatteryCapacity = [int]($DeviceMsg.BatteryMSG.capacity)
         $r.BatteryStatus = [int]($DeviceMsg.BatteryMSG.status)
+        $r.BatteryTempError = [bool]($DeviceMsg.BatteryMSG.temp_err)
+        if ($null -ne $DeviceMsg.BatteryMSG.timestamp) { $r.BatteryTimestamp = [double]($DeviceMsg.BatteryMSG.timestamp) }
     }
 
-    # State
+    # Body (BodyMsg)
+    if ($DeviceMsg.BodyMsg -and $null -ne $DeviceMsg.BodyMsg.recharge_state) {
+        $r.RechargeState = [int]($DeviceMsg.BodyMsg.recharge_state)
+    }
+
+    # State (StateMSG)
     if ($DeviceMsg.StateMSG) {
         $r.WorkingState = [int]($DeviceMsg.StateMSG.working_state)
         $r.ChargingStatus = [int]($DeviceMsg.StateMSG.charging_status)
@@ -218,21 +239,38 @@ function ConvertTo-YarboRobot {
     }
     if ($DeviceMsg.RTKMSG) {
         $r.Heading = [double]($DeviceMsg.RTKMSG.heading)
+        if ($null -ne $DeviceMsg.RTKMSG.heading_status) { $r.RtkHeadingStatus = [int]($DeviceMsg.RTKMSG.heading_status) }
         $r.RtkStatus = [string]($DeviceMsg.RTKMSG.status)
+        if ($null -ne $DeviceMsg.RTKMSG.heading_dop) { $r.RtkHeadingDop = [double]($DeviceMsg.RTKMSG.heading_dop) }
     }
     if ($null -ne $DeviceMsg.combined_odom_confidence) {
         $r.OdomConfidence = [double]($DeviceMsg.combined_odom_confidence)
     }
 
-    # Hardware
-    if ($DeviceMsg.RunningStatusMSG) { $r.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle) }
+    # Hardware (RunningStatusMSG, led, wireless_recharge)
+    if ($DeviceMsg.RunningStatusMSG) {
+        $r.ChuteAngle = [int]($DeviceMsg.RunningStatusMSG.chute_angle)
+        if ($null -ne $DeviceMsg.RunningStatusMSG.rain_sensor_data) { $r.RainSensorData = [int]($DeviceMsg.RunningStatusMSG.rain_sensor_data) }
+    }
     if ($null -ne $DeviceMsg.led) { $r.LedRegister = [string]($DeviceMsg.led) }
     if ($DeviceMsg.wireless_recharge) {
+        $r.WirelessChargeState = [int]($DeviceMsg.wireless_recharge.state)
         $r.WirelessChargeVoltage = [double]($DeviceMsg.wireless_recharge.output_voltage)
         $r.WirelessChargeCurrent = [double]($DeviceMsg.wireless_recharge.output_current)
+        $r.WirelessChargeErrorCode = [int]($DeviceMsg.wireless_recharge.error_code)
     }
 
-    # Network
+    # Ultrasonic (ultrasonic_msg)
+    if ($DeviceMsg.ultrasonic_msg) {
+        $r.UltrasonicLeftFront = [int]($DeviceMsg.ultrasonic_msg.lf_dis)
+        $r.UltrasonicMiddle = [int]($DeviceMsg.ultrasonic_msg.mt_dis)
+        $r.UltrasonicRightFront = [int]($DeviceMsg.ultrasonic_msg.rf_dis)
+    }
+
+    # Device message timestamp (root)
+    if ($null -ne $DeviceMsg.timestamp) { $r.DeviceTimestamp = [double]($DeviceMsg.timestamp) }
+
+    # Network (route_priority)
     if ($DeviceMsg.route_priority) {
         $r.RoutePriority = @{}
         $DeviceMsg.route_priority.PSObject.Properties | ForEach-Object { $r.RoutePriority[$_.Name] = $_.Value }

--- a/src/PSYarbo/Private/TelemetryParser.ps1
+++ b/src/PSYarbo/Private/TelemetryParser.ps1
@@ -80,6 +80,8 @@ function Set-YarboCommonFields {
     .SYNOPSIS
         Maps common DeviceMSG fields to a target object (YarboTelemetry or YarboRobot).
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal helper only mutates in-memory object; no system state change.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'CommonFields denotes the shared DeviceMSG field group; singular would be misleading.')]
     param(
         [Parameter(Mandatory)]
         [PSCustomObject]$DeviceMsg,

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -64,39 +64,39 @@ function Connect-YarboCloud {
             if (-not $Password) {
                 $stored = Get-YarboCloudCredential -Email $Email
                 if ($stored) {
-                if ($stored.RefreshToken) {
-                    try {
-                        $session.Email = $Email
-                        $session.RefreshToken = $stored.RefreshToken
-                        $session.RefreshAuth()
-                        # Fetch bound serial numbers if not populated by RefreshAuth
-                        if (-not $session.BoundSerialNumbers) {
-                            try {
-                                $deviceData = $session.Invoke('GET', '/yarbo/robot-service/commonUser/userRobotBind/getUserRobotBindVos', $null)
-                                if ($deviceData.deviceList) {
-                                    $session.BoundSerialNumbers = @($deviceData.deviceList | ForEach-Object { $_.sn })
-                                }
-                            } catch {
-                                Write-Verbose "[Connect-YarboCloud] Could not fetch bound serial numbers: $($_.Exception.Message)"
-                            }
-                        }
-                        # Persist potentially-rotated refresh token (issue #10)
+                    if ($stored.RefreshToken) {
                         try {
-                            Save-YarboCredential -Name 'CloudRefreshToken' -Value $session.RefreshToken
-                            if ($session.Email) {
-                                Save-YarboCloudCredential -Email $session.Email -Password $stored.Password -RefreshToken $session.RefreshToken
+                            $session.Email = $Email
+                            $session.RefreshToken = $stored.RefreshToken
+                            $session.RefreshAuth()
+                            # Fetch bound serial numbers if not populated by RefreshAuth
+                            if (-not $session.BoundSerialNumbers) {
+                                try {
+                                    $deviceData = $session.Invoke('GET', '/yarbo/robot-service/commonUser/userRobotBind/getUserRobotBindVos', $null)
+                                    if ($deviceData.deviceList) {
+                                        $session.BoundSerialNumbers = @($deviceData.deviceList | ForEach-Object { $_.sn })
+                                    }
+                                } catch {
+                                    Write-Verbose "[Connect-YarboCloud] Could not fetch bound serial numbers: $($_.Exception.Message)"
+                                }
                             }
-                            Write-Verbose "[Connect-YarboCloud] Refresh token saved via CredentialHelper for future sessions"
+                            # Persist potentially-rotated refresh token (issue #10)
+                            try {
+                                Save-YarboCredential -Name 'CloudRefreshToken' -Value $session.RefreshToken
+                                if ($session.Email) {
+                                    Save-YarboCloudCredential -Email $session.Email -Password $stored.Password -RefreshToken $session.RefreshToken
+                                }
+                                Write-Verbose "[Connect-YarboCloud] Refresh token saved via CredentialHelper for future sessions"
+                            } catch {
+                                Write-Verbose "[Connect-YarboCloud] Could not save refresh token: $($_.Exception.Message)"
+                            }
+                            if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
+                            $script:YarboCloudSession = $session
+                            return $session
                         } catch {
-                            Write-Verbose "[Connect-YarboCloud] Could not save refresh token: $($_.Exception.Message)"
+                            Write-Verbose "[Connect-YarboCloud] Refresh token failed, falling back to password: $($_.Exception.Message)"
                         }
-                        if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
-                        $script:YarboCloudSession = $session
-                        return $session
-                    } catch {
-                        Write-Verbose "[Connect-YarboCloud] Refresh token failed, falling back to password: $($_.Exception.Message)"
                     }
-                }
                     if ($stored.Password) { $Password = $stored.Password }
                 }
                 if (-not $Password) {

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -32,7 +32,7 @@ function Connect-YarboCloud {
     [CmdletBinding(DefaultParameterSetName = 'Credential')]
     [OutputType([YarboCloudSession])]
     param(
-        [Parameter(Mandatory, ParameterSetName = 'Credential')]
+        [Parameter(ParameterSetName = 'Credential')]
         [string]$Email,
 
         [Parameter(Mandatory, ParameterSetName = 'Credential')]
@@ -48,6 +48,20 @@ function Connect-YarboCloud {
     $session = [YarboCloudSession]::new()
 
     try {
+        if ($PSCmdlet.ParameterSetName -eq 'Credential') {
+            # Resolve email from env or config if not provided (issue #9)
+            if (-not $Email) {
+                $cfg = Get-YarboConfig -Overrides @{}
+                $Email = $cfg['Email']
+            }
+            if (-not $Email) {
+                throw [YarboCloudAuthException]::new(
+                    'Email is required. Provide -Email, set $env:YARBO_EMAIL, or add Email to ~/.psyarbo/config.json.',
+                    'EMAIL_REQUIRED'
+                )
+            }
+        }
+
         if ($PSCmdlet.ParameterSetName -eq 'Token') {
             $session.RefreshToken = $RefreshToken
             $session.RefreshAuth()

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -32,7 +32,7 @@ function Connect-YarboCloud {
     [CmdletBinding(DefaultParameterSetName = 'Credential')]
     [OutputType([YarboCloudSession])]
     param(
-        [Parameter(ParameterSetName = 'Credential')]
+        [Parameter(Mandatory, ParameterSetName = 'Credential')]
         [string]$Email,
 
         [Parameter(ParameterSetName = 'Credential')]

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -35,7 +35,7 @@ function Connect-YarboCloud {
         [Parameter(ParameterSetName = 'Credential')]
         [string]$Email,
 
-        [Parameter(Mandatory, ParameterSetName = 'Credential')]
+        [Parameter(ParameterSetName = 'Credential')]
         [SecureString]$Password,
 
         [Parameter(Mandatory, ParameterSetName = 'Token')]
@@ -59,6 +59,25 @@ function Connect-YarboCloud {
                     'Email is required. Provide -Email, set $env:YARBO_EMAIL, or add Email to ~/.psyarbo/config.json.',
                     'EMAIL_REQUIRED'
                 )
+            }
+            # When -Email without -Password, try stored credentials (issue #10)
+            if (-not $Password) {
+                $stored = Get-YarboCloudCredential -Email $Email
+                if ($stored.RefreshToken) {
+                    $session.Email = $Email
+                    $session.RefreshToken = $stored.RefreshToken
+                    $session.RefreshAuth()
+                    if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
+                    $script:YarboCloudSession = $session
+                    return $session
+                }
+                if ($stored.Password) { $Password = $stored.Password }
+                else {
+                    throw [YarboCloudAuthException]::new(
+                        'Password is required. Provide -Password or save credentials with Connect-YarboCloud -Email -Password first.',
+                        'PASSWORD_REQUIRED'
+                    )
+                }
             }
         }
 
@@ -136,10 +155,12 @@ function Connect-YarboCloud {
             $session.TokenExpiry = [datetime]::UtcNow.AddSeconds($result.data.expiresIn)
             $session.BoundSerialNumbers = @($result.data.snList)
 
-            # Persist refresh token for future sessions (allows auto-login via:
-            #   Connect-YarboCloud -RefreshToken (Get-YarboCredential -Name 'CloudRefreshToken'))
+            # Persist refresh token for future sessions (issue #10: SecretManagement + email-keyed storage)
             try {
                 Save-YarboCredential -Name 'CloudRefreshToken' -Value $session.RefreshToken
+                if ($session.Email) {
+                    Save-YarboCloudCredential -Email $session.Email -Password $Password -RefreshToken $session.RefreshToken
+                }
                 Write-Verbose "[Connect-YarboCloud] Refresh token saved via CredentialHelper for future sessions"
             } catch {
                 Write-Verbose "[Connect-YarboCloud] Could not save refresh token: $($_.Exception.Message)"

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -63,16 +63,18 @@ function Connect-YarboCloud {
             # When -Email without -Password, try stored credentials (issue #10)
             if (-not $Password) {
                 $stored = Get-YarboCloudCredential -Email $Email
-                if ($stored.RefreshToken) {
-                    $session.Email = $Email
-                    $session.RefreshToken = $stored.RefreshToken
-                    $session.RefreshAuth()
-                    if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
-                    $script:YarboCloudSession = $session
-                    return $session
+                if ($stored) {
+                    if ($stored.RefreshToken) {
+                        $session.Email = $Email
+                        $session.RefreshToken = $stored.RefreshToken
+                        $session.RefreshAuth()
+                        if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
+                        $script:YarboCloudSession = $session
+                        return $session
+                    }
+                    if ($stored.Password) { $Password = $stored.Password }
                 }
-                if ($stored.Password) { $Password = $stored.Password }
-                else {
+                if (-not $Password) {
                     throw [YarboCloudAuthException]::new(
                         'Password is required. Provide -Password or save credentials with Connect-YarboCloud -Email -Password first.',
                         'PASSWORD_REQUIRED'

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -32,7 +32,7 @@ function Connect-YarboCloud {
     [CmdletBinding(DefaultParameterSetName = 'Credential')]
     [OutputType([YarboCloudSession])]
     param(
-        [Parameter(Mandatory, ParameterSetName = 'Credential')]
+        [Parameter(ParameterSetName = 'Credential')]
         [string]$Email,
 
         [Parameter(ParameterSetName = 'Credential')]

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -65,12 +65,16 @@ function Connect-YarboCloud {
                 $stored = Get-YarboCloudCredential -Email $Email
                 if ($stored) {
                     if ($stored.RefreshToken) {
-                        $session.Email = $Email
-                        $session.RefreshToken = $stored.RefreshToken
-                        $session.RefreshAuth()
-                        if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
-                        $script:YarboCloudSession = $session
-                        return $session
+                        try {
+                            $session.Email = $Email
+                            $session.RefreshToken = $stored.RefreshToken
+                            $session.RefreshAuth()
+                            if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
+                            $script:YarboCloudSession = $session
+                            return $session
+                        } catch {
+                            Write-Verbose "[Connect-YarboCloud] Refresh token failed, falling back to password: $($_.Exception.Message)"
+                        }
                     }
                     if ($stored.Password) { $Password = $stored.Password }
                 }

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -64,28 +64,39 @@ function Connect-YarboCloud {
             if (-not $Password) {
                 $stored = Get-YarboCloudCredential -Email $Email
                 if ($stored) {
-                    if ($stored.RefreshToken) {
-                        try {
-                            $session.Email = $Email
-                            $session.RefreshToken = $stored.RefreshToken
-                            $session.RefreshAuth()
-                            # Persist potentially-rotated refresh token (issue #10)
+                if ($stored.RefreshToken) {
+                    try {
+                        $session.Email = $Email
+                        $session.RefreshToken = $stored.RefreshToken
+                        $session.RefreshAuth()
+                        # Fetch bound serial numbers if not populated by RefreshAuth
+                        if (-not $session.BoundSerialNumbers) {
                             try {
-                                Save-YarboCredential -Name 'CloudRefreshToken' -Value $session.RefreshToken
-                                if ($session.Email) {
-                                    Save-YarboCloudCredential -Email $session.Email -Password $stored.Password -RefreshToken $session.RefreshToken
+                                $deviceData = $session.Invoke('GET', '/yarbo/robot-service/commonUser/userRobotBind/getUserRobotBindVos', $null)
+                                if ($deviceData.deviceList) {
+                                    $session.BoundSerialNumbers = @($deviceData.deviceList | ForEach-Object { $_.sn })
                                 }
-                                Write-Verbose "[Connect-YarboCloud] Refresh token saved via CredentialHelper for future sessions"
                             } catch {
-                                Write-Verbose "[Connect-YarboCloud] Could not save refresh token: $($_.Exception.Message)"
+                                Write-Verbose "[Connect-YarboCloud] Could not fetch bound serial numbers: $($_.Exception.Message)"
                             }
-                            if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
-                            $script:YarboCloudSession = $session
-                            return $session
-                        } catch {
-                            Write-Verbose "[Connect-YarboCloud] Refresh token failed, falling back to password: $($_.Exception.Message)"
                         }
+                        # Persist potentially-rotated refresh token (issue #10)
+                        try {
+                            Save-YarboCredential -Name 'CloudRefreshToken' -Value $session.RefreshToken
+                            if ($session.Email) {
+                                Save-YarboCloudCredential -Email $session.Email -Password $stored.Password -RefreshToken $session.RefreshToken
+                            }
+                            Write-Verbose "[Connect-YarboCloud] Refresh token saved via CredentialHelper for future sessions"
+                        } catch {
+                            Write-Verbose "[Connect-YarboCloud] Could not save refresh token: $($_.Exception.Message)"
+                        }
+                        if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
+                        $script:YarboCloudSession = $session
+                        return $session
+                    } catch {
+                        Write-Verbose "[Connect-YarboCloud] Refresh token failed, falling back to password: $($_.Exception.Message)"
                     }
+                }
                     if ($stored.Password) { $Password = $stored.Password }
                 }
                 if (-not $Password) {

--- a/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
+++ b/src/PSYarbo/Public/Cloud/Connect-YarboCloud.ps1
@@ -69,6 +69,16 @@ function Connect-YarboCloud {
                             $session.Email = $Email
                             $session.RefreshToken = $stored.RefreshToken
                             $session.RefreshAuth()
+                            # Persist potentially-rotated refresh token (issue #10)
+                            try {
+                                Save-YarboCredential -Name 'CloudRefreshToken' -Value $session.RefreshToken
+                                if ($session.Email) {
+                                    Save-YarboCloudCredential -Email $session.Email -Password $stored.Password -RefreshToken $session.RefreshToken
+                                }
+                                Write-Verbose "[Connect-YarboCloud] Refresh token saved via CredentialHelper for future sessions"
+                            } catch {
+                                Write-Verbose "[Connect-YarboCloud] Could not save refresh token: $($_.Exception.Message)"
+                            }
                             if ($script:YarboCloudSession) { $script:YarboCloudSession.Dispose() }
                             $script:YarboCloudSession = $session
                             return $session

--- a/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
@@ -114,7 +114,7 @@ function Connect-Yarbo {
             $conn.MqttClient = $conn.MqttFactory.CreateMqttClient()
 
             # Attach message handler before connecting (MQTTnet requirement)
-            [PSYarbo.Mqtt.MessageReceivedAdapter]::Callback = [Func[object, System.Threading.Tasks.Task]] {
+            $callback = [Func[object, System.Threading.Tasks.Task]] {
                 param($args)
                 $topic = $args.ApplicationMessage.Topic
                 $payload = $args.ApplicationMessage.PayloadSegment.ToArray()
@@ -212,8 +212,9 @@ function Connect-Yarbo {
 
                 return [System.Threading.Tasks.Task]::CompletedTask
             }.GetNewClosure()
+            [PSYarbo.Mqtt.MessageReceivedAdapter]::RegisterCallback($conn.MqttClient, $callback)
             $argsType = $script:MqttAssembly.GetType('MQTTnet.Client.MqttApplicationMessageReceivedEventArgs')
-            $funcType = [Func`2].MakeGenericType(@($argsType, [System.Threading.Tasks.Task]))
+            $funcType = [Func`3].MakeGenericType(@([object], $argsType, [System.Threading.Tasks.Task]))
             $handlerMethod = [PSYarbo.Mqtt.MessageReceivedAdapter].GetMethod('Handler')
             $handlerDelegate = [System.Delegate]::CreateDelegate($funcType, $null, $handlerMethod)
             $conn.MqttClient.GetType().GetMethod('add_ApplicationMessageReceivedAsync').Invoke($conn.MqttClient, @($handlerDelegate)) | Out-Null

--- a/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
@@ -115,9 +115,9 @@ function Connect-Yarbo {
 
             # Attach message handler before connecting (MQTTnet requirement)
             $callback = [Func[object, System.Threading.Tasks.Task]] {
-                param($args)
-                $topic = $args.ApplicationMessage.Topic
-                $payload = $args.ApplicationMessage.PayloadSegment.ToArray()
+                param($eventArgs)
+                $topic = $eventArgs.ApplicationMessage.Topic
+                $payload = $eventArgs.ApplicationMessage.PayloadSegment.ToArray()
 
                 if ($null -eq $payload -or $payload.Length -eq 0) {
                     return [System.Threading.Tasks.Task]::CompletedTask

--- a/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
@@ -30,7 +30,7 @@ function Connect-Yarbo {
     Return the connection object (also returned by default).
 
 .EXAMPLE
-    Connect-Yarbo -Broker 192.168.1.24 -SerialNumber 24400102L8HO5227
+    Connect-Yarbo -Broker <rover-ip> -SerialNumber <serial-number>
 
 .EXAMPLE
     Find-Yarbo | Connect-Yarbo
@@ -113,13 +113,117 @@ function Connect-Yarbo {
             $conn.MqttFactory = [System.Activator]::CreateInstance($factory)
             $conn.MqttClient = $conn.MqttFactory.CreateMqttClient()
 
-            # Build connection options
+            # Attach message handler before connecting (MQTTnet requirement)
+            [PSYarbo.Mqtt.MessageReceivedAdapter]::Callback = [Func[object, System.Threading.Tasks.Task]] {
+                param($args)
+                $topic = $args.ApplicationMessage.Topic
+                $payload = $args.ApplicationMessage.PayloadSegment.ToArray()
+
+                if ($null -eq $payload -or $payload.Length -eq 0) {
+                    return [System.Threading.Tasks.Task]::CompletedTask
+                }
+
+                if ($topic -like '*/device/data_feedback') {
+                    $decoded = ConvertFrom-ZlibPayload -Data $payload
+                    if ($decoded) {
+                        $conn.ResponseQueue.Enqueue($decoded)
+                        $conn.ResponseSignal.Release() | Out-Null
+                    }
+                } elseif ($topic -like '*/device/heart_beat') {
+                    $decoded = ConvertFrom-ZlibPayload -Data $payload
+                    if ($decoded) {
+                        $conn.LastHeartbeat = [datetime]::UtcNow
+                        $conn.LastWorkingState = [int]($decoded.working_state)
+                        if ($decoded.working_state -eq 0 -and $conn.ControllerAcquired) {
+                            $conn.ControllerAcquired = $false
+                            $conn.State = [MqttConnectionState]::Connected
+                        }
+                        $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
+                                MessageType = 'HeartBeat'
+                                Timestamp   = [datetime]::UtcNow
+                                Data        = $decoded
+                            })
+                        $conn.TelemetrySignal.Release() | Out-Null
+                    }
+                } elseif ($topic -like '*/device/DeviceMSG') {
+                    $decoded = ConvertFrom-ZlibPayload -Data $payload
+                    if ($decoded) {
+                        $conn.Robot = ConvertTo-YarboRobot -DeviceMsg $decoded -SerialNumber $conn.SerialNumber -Broker $conn.Broker -Port $conn.Port
+                        $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
+                                MessageType = 'DeviceMSG'
+                                Timestamp   = [datetime]::UtcNow
+                                Data        = $decoded
+                            })
+                        $conn.TelemetrySignal.Release() | Out-Null
+                        $conn.TelemetryLog.Enqueue([PSCustomObject]@{
+                                Timestamp   = [datetime]::UtcNow
+                                MessageType = 'DeviceMSG'
+                                Direction   = 'Pushed'
+                                Topic       = $topic
+                            })
+                        if ($conn.TelemetryLog.Count -gt 200) {
+                            $discard = $null
+                            $conn.TelemetryLog.TryDequeue([ref]$discard) | Out-Null
+                        }
+                    }
+                } elseif ($topic -like '*/device/plan_feedback') {
+                    $decoded = ConvertFrom-ZlibPayload -Data $payload
+                    if ($decoded) {
+                        $conn.LastPlanFeedback = $decoded
+                        $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
+                                MessageType = 'PlanFeedback'
+                                Timestamp   = [datetime]::UtcNow
+                                Data        = $decoded
+                            })
+                        $conn.TelemetrySignal.Release() | Out-Null
+                        $conn.TelemetryLog.Enqueue([PSCustomObject]@{
+                                Timestamp   = [datetime]::UtcNow
+                                MessageType = 'PlanFeedback'
+                                Direction   = 'Pushed'
+                                Topic       = $topic
+                            })
+                        if ($conn.TelemetryLog.Count -gt 200) {
+                            $discard = $null
+                            $conn.TelemetryLog.TryDequeue([ref]$discard) | Out-Null
+                        }
+                    }
+                } elseif ($topic -like '*/device/recharge_feedback') {
+                    $decoded = ConvertFrom-ZlibPayload -Data $payload
+                    if ($decoded) {
+                        $conn.LastRechargeFeedback = $decoded
+                        $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
+                                MessageType = 'RechargeFeedback'
+                                Timestamp   = [datetime]::UtcNow
+                                Data        = $decoded
+                            })
+                        $conn.TelemetrySignal.Release() | Out-Null
+                        $conn.TelemetryLog.Enqueue([PSCustomObject]@{
+                                Timestamp   = [datetime]::UtcNow
+                                MessageType = 'RechargeFeedback'
+                                Direction   = 'Pushed'
+                                Topic       = $topic
+                            })
+                        if ($conn.TelemetryLog.Count -gt 200) {
+                            $discard = $null
+                            $conn.TelemetryLog.TryDequeue([ref]$discard) | Out-Null
+                        }
+                    }
+                }
+
+                return [System.Threading.Tasks.Task]::CompletedTask
+            }.GetNewClosure()
+            $argsType = $script:MqttAssembly.GetType('MQTTnet.Client.MqttApplicationMessageReceivedEventArgs')
+            $funcType = [Func`2].MakeGenericType(@($argsType, [System.Threading.Tasks.Task]))
+            $handlerMethod = [PSYarbo.Mqtt.MessageReceivedAdapter].GetMethod('Handler')
+            $handlerDelegate = [System.Delegate]::CreateDelegate($funcType, $null, $handlerMethod)
+            $conn.MqttClient.GetType().GetMethod('add_ApplicationMessageReceivedAsync').Invoke($conn.MqttClient, @($handlerDelegate)) | Out-Null
+
+            # Build connection options and connect
             $optionsBuilder = $conn.MqttFactory.CreateClientOptionsBuilder()
             $options = $optionsBuilder.WithTcpServer($Broker, $Port).WithClientId($effectiveClientId).WithTimeout(
                 [TimeSpan]::FromSeconds($TimeoutSeconds)
             ).Build()
 
-            # Connect
             $conn.MqttClient.ConnectAsync($options, [System.Threading.CancellationToken]::None).GetAwaiter().GetResult() | Out-Null
             $conn.State = [MqttConnectionState]::Connected
             $conn.ConnectedAt = [datetime]::UtcNow
@@ -130,111 +234,6 @@ function Connect-Yarbo {
             $subBuilder = $conn.MqttFactory.CreateSubscribeOptionsBuilder()
             $subOptions = $subBuilder.WithTopicFilter("snowbot/$SerialNumber/device/#").Build()
             $conn.MqttClient.SubscribeAsync($subOptions, [System.Threading.CancellationToken]::None).GetAwaiter().GetResult() | Out-Null
-
-            # Set up message handler for routing responses
-            $conn.MqttClient.ApplicationMessageReceivedAsync.Add({
-                    param($args)
-                    $topic = $args.ApplicationMessage.Topic
-                    $payload = $args.ApplicationMessage.PayloadSegment.ToArray()
-
-                    # Guard: skip empty/null payloads
-                    if ($null -eq $payload -or $payload.Length -eq 0) {
-                        return [System.Threading.Tasks.Task]::CompletedTask
-                    }
-
-                    if ($topic -like '*/device/data_feedback') {
-                        $decoded = ConvertFrom-ZlibPayload -Data $payload
-                        if ($decoded) {
-                            $conn.ResponseQueue.Enqueue($decoded)
-                            $conn.ResponseSignal.Release() | Out-Null  # Wake Send-MqttCommand waiter
-                        }
-                    } elseif ($topic -like '*/device/heart_beat') {
-                        $decoded = ConvertFrom-ZlibPayload -Data $payload
-                        if ($decoded) {
-                            $conn.LastHeartbeat = [datetime]::UtcNow
-                            $conn.LastWorkingState = [int]($decoded.working_state)
-                            # Reset controller on sleep
-                            if ($decoded.working_state -eq 0 -and $conn.ControllerAcquired) {
-                                $conn.ControllerAcquired = $false
-                                $conn.State = [MqttConnectionState]::Connected
-                            }
-                            # Enqueue to telemetry event stream
-                            $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
-                                    MessageType = 'HeartBeat'
-                                    Timestamp   = [datetime]::UtcNow
-                                    Data        = $decoded
-                                })
-                            $conn.TelemetrySignal.Release() | Out-Null
-                        }
-                    } elseif ($topic -like '*/device/DeviceMSG') {
-                        $decoded = ConvertFrom-ZlibPayload -Data $payload
-                        if ($decoded) {
-                            $conn.Robot = ConvertTo-YarboRobot -DeviceMsg $decoded -SerialNumber $conn.SerialNumber -Broker $conn.Broker -Port $conn.Port
-                            # Enqueue to event-driven telemetry stream
-                            $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
-                                    MessageType = 'DeviceMSG'
-                                    Timestamp   = [datetime]::UtcNow
-                                    Data        = $decoded
-                                })
-                            $conn.TelemetrySignal.Release() | Out-Null
-                            # Keep a bounded telemetry log (last 200 entries)
-                            $conn.TelemetryLog.Enqueue([PSCustomObject]@{
-                                    Timestamp   = [datetime]::UtcNow
-                                    MessageType = 'DeviceMSG'
-                                    Direction   = 'Pushed'
-                                    Topic       = $topic
-                                })
-                            if ($conn.TelemetryLog.Count -gt 200) { 
-                                $discard = $null
-                                $conn.TelemetryLog.TryDequeue([ref]$discard) | Out-Null
-                            }
-                        }
-                    } elseif ($topic -like '*/device/plan_feedback') {
-                        $decoded = ConvertFrom-ZlibPayload -Data $payload
-                        if ($decoded) {
-                            $conn.LastPlanFeedback = $decoded
-                            $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
-                                    MessageType = 'PlanFeedback'
-                                    Timestamp   = [datetime]::UtcNow
-                                    Data        = $decoded
-                                })
-                            $conn.TelemetrySignal.Release() | Out-Null
-                            $conn.TelemetryLog.Enqueue([PSCustomObject]@{
-                                    Timestamp   = [datetime]::UtcNow
-                                    MessageType = 'PlanFeedback'
-                                    Direction   = 'Pushed'
-                                    Topic       = $topic
-                                })
-                            if ($conn.TelemetryLog.Count -gt 200) { 
-                                $discard = $null
-                                $conn.TelemetryLog.TryDequeue([ref]$discard) | Out-Null
-                            }
-                        }
-                    } elseif ($topic -like '*/device/recharge_feedback') {
-                        $decoded = ConvertFrom-ZlibPayload -Data $payload
-                        if ($decoded) {
-                            $conn.LastRechargeFeedback = $decoded
-                            $conn.TelemetryQueue.Enqueue([PSCustomObject]@{
-                                    MessageType = 'RechargeFeedback'
-                                    Timestamp   = [datetime]::UtcNow
-                                    Data        = $decoded
-                                })
-                            $conn.TelemetrySignal.Release() | Out-Null
-                            $conn.TelemetryLog.Enqueue([PSCustomObject]@{
-                                    Timestamp   = [datetime]::UtcNow
-                                    MessageType = 'RechargeFeedback'
-                                    Direction   = 'Pushed'
-                                    Topic       = $topic
-                                })
-                            if ($conn.TelemetryLog.Count -gt 200) { 
-                                $discard = $null
-                                $conn.TelemetryLog.TryDequeue([ref]$discard) | Out-Null
-                            }
-                        }
-                    }
-
-                    return [System.Threading.Tasks.Task]::CompletedTask
-                }.GetNewClosure())
 
             # Acquire controller unless skipped
             if (-not $NoControllerInit) {

--- a/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Connect-Yarbo.ps1
@@ -213,10 +213,7 @@ function Connect-Yarbo {
                 return [System.Threading.Tasks.Task]::CompletedTask
             }.GetNewClosure()
             [PSYarbo.Mqtt.MessageReceivedAdapter]::RegisterCallback($conn.MqttClient, $callback)
-            $argsType = $script:MqttAssembly.GetType('MQTTnet.Client.MqttApplicationMessageReceivedEventArgs')
-            $funcType = [Func`3].MakeGenericType(@([object], $argsType, [System.Threading.Tasks.Task]))
-            $handlerMethod = [PSYarbo.Mqtt.MessageReceivedAdapter].GetMethod('Handler')
-            $handlerDelegate = [System.Delegate]::CreateDelegate($funcType, $null, $handlerMethod)
+            $handlerDelegate = [PSYarbo.Mqtt.MessageReceivedAdapter]::GetHandler($conn.MqttClient)
             $conn.MqttClient.GetType().GetMethod('add_ApplicationMessageReceivedAsync').Invoke($conn.MqttClient, @($handlerDelegate)) | Out-Null
 
             # Build connection options and connect

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -15,7 +15,7 @@ function Find-Yarbo {
     TimeoutSeconds are silently skipped.
 
 .PARAMETER Subnet
-    Network subnet(s) to scan in CIDR notation (e.g. 192.168.1.0/24). When not specified, scans all networks this machine has an IP on (LAN, Wi‑Fi, etc.). Prefix must be /16–/30.
+    Network subnet(s) to scan in CIDR notation (e.g. 192.0.2.0/24). When not specified, scans all networks this machine has an IP on (LAN, Wi‑Fi, etc.). Prefix must be /16–/30.
 
 .PARAMETER TimeoutSeconds
     How long to wait for each broker to produce a heart_beat. Default: 5.
@@ -34,10 +34,10 @@ function Find-Yarbo {
     Scans all local networks (auto-detected).
 
 .EXAMPLE
-    Find-Yarbo -Subnet 192.168.1.0/24 -TimeoutSeconds 10
+    Find-Yarbo -Subnet 192.0.2.0/24 -TimeoutSeconds 10
 
 .EXAMPLE
-    Find-Yarbo -Subnet 192.168.0.0/22 -MaxHosts 1024
+    Find-Yarbo -Subnet 192.0.2.0/22 -MaxHosts 1024
 
 .LINK
     Connect-Yarbo
@@ -74,7 +74,7 @@ function Find-Yarbo {
     if ([string]::IsNullOrWhiteSpace($Subnet)) {
         $subnetsToScan = @(Get-PSYarboLocalSubnets)
         if ($subnetsToScan.Count -eq 0) {
-            $subnetsToScan = @('192.168.0.0/23')
+            $subnetsToScan = @('192.0.2.0/24')
             Write-Verbose "[Find-Yarbo] No local subnets detected; using fallback $($subnetsToScan[0])"
         } else {
             Write-Verbose "[Find-Yarbo] Using local subnets: $($subnetsToScan -join ', ')"

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -49,9 +49,9 @@ function Find-Yarbo {
         [Parameter()]
         [AllowEmptyString()]
         [ValidateScript({
-            if ([string]::IsNullOrEmpty($_)) { return $true }
-            $_ -match '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
-        })]
+                if ([string]::IsNullOrEmpty($_)) { return $true }
+                $_ -match '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+            })]
         [string]$Subnet = '',
 
         [Parameter()]
@@ -72,7 +72,7 @@ function Find-Yarbo {
 
     # ── 1. Resolve subnets to scan (local interfaces or -Subnet) ───────────────
     if ([string]::IsNullOrWhiteSpace($Subnet)) {
-        $subnetsToScan = @(Get-PSYarboLocalSubnets)
+        $subnetsToScan = @(Get-PSYarboLocalSubnet)
         if ($subnetsToScan.Count -eq 0) {
             $subnetsToScan = @('192.168.1.0/24')
             Write-Verbose "[Find-Yarbo] No local subnets detected; using fallback $($subnetsToScan[0])"
@@ -87,7 +87,7 @@ function Find-Yarbo {
     $hostCount = $ipList.Count
     Write-Verbose "[Find-Yarbo] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts for MQTT brokers on port $Port"
     if ($hostCount -gt 512) {
-        Write-Warning "Find-Yarbo: Scanning $hostCount hosts; this may be slow. Use -MaxHosts to scan more (will take longer), or reduce -MaxHosts for a quicker scan."
+        Write-Warning "Find-Yarbo: Scanning $hostCount hosts; this may be slow. Consider using a more specific -Subnet or reducing -MaxHosts to speed up the scan."
     }
 
     # ── 2. Parallel TCP probe — collect candidates ────────────────────────────

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -113,7 +113,7 @@ function Find-Yarbo {
             }
         } -ThrottleLimit $ThrottleLimit | Where-Object { $null -ne $_ }
     )
-    $candidates = @($tcpCandidates)
+    $candidates = @($tcpCandidates) | Select-Object -Unique
     Write-Verbose "[Find-Yarbo] TCP probe found $($candidates.Count) candidate(s)"
 
     if ($candidates.Count -eq 0) {

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -187,13 +187,12 @@ function Find-Yarbo {
         }
     }
     foreach ($endpoints in $discovered.Values) {
-        foreach ($ep in $endpoints) {
-            $r = [YarboRobot]::new()
-            $r.Broker = $ep.IP
-            $r.Port = $ep.Port
-            $r.SerialNumber = $ep.SerialNumber
-            $r.LastUpdated = [datetime]::UtcNow
-            Write-Output $r
-        }
+        $ep = $endpoints[0]
+        $r = [YarboRobot]::new()
+        $r.Broker = $ep.IP
+        $r.Port = $ep.Port
+        $r.SerialNumber = $ep.SerialNumber
+        $r.LastUpdated = [datetime]::UtcNow
+        Write-Output $r
     }
 }

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -15,9 +15,7 @@ function Find-Yarbo {
     TimeoutSeconds are silently skipped.
 
 .PARAMETER Subnet
-    Network subnet to scan in CIDR notation. Default: 192.168.1.0/24.
-    Prefix length must be /16 or longer (/24 recommended).
-    To allow scanning larger subnets, specify -MaxHosts explicitly.
+    Network subnet(s) to scan in CIDR notation (e.g. 192.168.1.0/24). When not specified, scans all networks this machine has an IP on (LAN, Wi‑Fi, etc.). Prefix must be /16–/30.
 
 .PARAMETER TimeoutSeconds
     How long to wait for each broker to produce a heart_beat. Default: 5.
@@ -26,17 +24,17 @@ function Find-Yarbo {
     MQTT port to scan. Default: 1883.
 
 .PARAMETER MaxHosts
-    Maximum number of hosts to scan. Acts as a safety guard against
-    accidentally scanning huge subnets. Default: 256.
+    Maximum number of hosts to scan. Default: 512 (so a single /23 is fully scanned).
 
 .PARAMETER ThrottleLimit
     Maximum number of concurrent TCP probe tasks. Default: 64.
 
 .EXAMPLE
     Find-Yarbo
+    Scans all local networks (auto-detected).
 
 .EXAMPLE
-    Find-Yarbo -Subnet 10.0.0.0/24 -TimeoutSeconds 10
+    Find-Yarbo -Subnet 192.168.1.0/24 -TimeoutSeconds 10
 
 .EXAMPLE
     Find-Yarbo -Subnet 192.168.0.0/22 -MaxHosts 1024
@@ -49,8 +47,12 @@ function Find-Yarbo {
     [OutputType([YarboRobot])]
     param(
         [Parameter()]
-        [ValidatePattern('^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$')]
-        [string]$Subnet = '192.168.1.0/24',
+        [AllowEmptyString()]
+        [ValidateScript({
+            if ([string]::IsNullOrEmpty($_)) { return $true }
+            $_ -match '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+        })]
+        [string]$Subnet = '',
 
         [Parameter()]
         [ValidateRange(1, 120)]
@@ -61,77 +63,80 @@ function Find-Yarbo {
 
         [Parameter()]
         [ValidateRange(1, 65534)]
-        [int]$MaxHosts = 256,
+        [int]$MaxHosts = 512,
 
         [Parameter()]
         [ValidateRange(1, 256)]
         [int]$ThrottleLimit = 64
     )
 
-    # ── 1. Parse and validate CIDR ─────────────────────────────────────────────
-    $parts = $Subnet -split '/'
-    $prefixLen = [int]$parts[1]
-
-    if ($prefixLen -lt 16) {
-        throw [System.ArgumentException]::new(
-            "Subnet prefix /$prefixLen is too large for safety. Use /16 or longer, or set -MaxHosts explicitly."
-        )
+    # ── 1. Resolve subnets to scan (local interfaces or -Subnet) ───────────────
+    if ([string]::IsNullOrWhiteSpace($Subnet)) {
+        $subnetsToScan = @(Get-PSYarboLocalSubnets)
+        if ($subnetsToScan.Count -eq 0) {
+            $subnetsToScan = @('192.168.0.0/23')
+            Write-Verbose "[Find-Yarbo] No local subnets detected; using fallback $($subnetsToScan[0])"
+        } else {
+            Write-Verbose "[Find-Yarbo] Using local subnets: $($subnetsToScan -join ', ')"
+        }
+    } else {
+        $subnetsToScan = @($Subnet.Trim())
     }
 
-    if ($prefixLen -gt 30) {
-        throw [System.ArgumentException]::new(
-            "Subnet prefix /$prefixLen has no scannable host addresses. Use /30 or shorter (/$prefixLen has $([math]::Max(0, [math]::Pow(2, 32 - $prefixLen) - 2)) usable hosts)."
-        )
+    $ipList = [System.Collections.Generic.List[string]]::new()
+    $remaining = $MaxHosts
+    foreach ($oneSubnet in $subnetsToScan) {
+        if ($remaining -le 0) { break }
+        $parts = $oneSubnet -split '/'
+        if ($parts.Count -lt 2) { continue }
+        $prefixLen = [int]$parts[1]
+        if ($prefixLen -lt 16 -or $prefixLen -gt 30) { continue }
+        $baseIp = [System.Net.IPAddress]::Parse($parts[0].Trim())
+        $baseBytes = $baseIp.GetAddressBytes()
+        [Array]::Reverse($baseBytes)
+        $hostBits = 32 - $prefixLen
+        $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
+        $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
+        $baseBytes = [System.BitConverter]::GetBytes($baseVal)
+        $maxInSubnet = [math]::Pow(2, $hostBits) - 2
+        $take = [math]::Min([int]$maxInSubnet, $remaining)
+        for ($i = 1; $i -le $take; $i++) {
+            $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
+            $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
+            [Array]::Reverse($newBytes)
+            $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())
+        }
+        $remaining -= $take
     }
-
-    $baseIp = [System.Net.IPAddress]::Parse($parts[0])
-    $baseBytes = $baseIp.GetAddressBytes()
-    # Ensure network address (zero host bits)
-    [Array]::Reverse($baseBytes)
-    $hostBits = 32 - $prefixLen
-    $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
-    $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
-    $baseBytes = [System.BitConverter]::GetBytes($baseVal)
-    $hostCount = [math]::Min([math]::Pow(2, $hostBits) - 2, $MaxHosts)
-
-    Write-Verbose "[Find-Yarbo] Scanning $Subnet ($hostCount hosts) for MQTT brokers on port $Port"
+    $hostCount = $ipList.Count
+    Write-Verbose "[Find-Yarbo] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts for MQTT brokers on port $Port"
+    if ($hostCount -gt 512) {
+        Write-Warning "Find-Yarbo: Scanning $hostCount hosts; this may be slow. Use -MaxHosts to scan more (will take longer), or reduce -MaxHosts for a quicker scan."
+    }
 
     # ── 2. Parallel TCP probe — collect candidates ────────────────────────────
     $tcpTimeoutMs = [int]($TimeoutSeconds * 1000 * 0.4)  # 40% budget for TCP
-    $semaphore = [System.Threading.SemaphoreSlim]::new($ThrottleLimit, $ThrottleLimit)
-    $tasks = [System.Collections.Generic.List[object]]::new()
-    $candidateIps = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
 
-    for ($i = 1; $i -le $hostCount; $i++) {
-        $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
-        $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
-        # Restore to network byte order for IPAddress constructor
-        [Array]::Reverse($newBytes)
-        $ip = [System.Net.IPAddress]::new($newBytes).ToString()
-
-        $semaphore.Wait() | Out-Null
-
-        $task = [System.Threading.Tasks.Task]::Run([scriptblock] {
+    $tcpCandidates = @(
+        $ipList | ForEach-Object -Parallel {
+            $ip = $_
+            $port = $using:Port
+            $timeoutMs = $using:tcpTimeoutMs
+            try {
+                $c = [System.Net.Sockets.TcpClient]::new()
                 try {
-                    $c = [System.Net.Sockets.TcpClient]::new()
-                    try {
-                        if ($c.ConnectAsync($ip, $Port).Wait($tcpTimeoutMs) -and $c.Connected) {
-                            $candidateIps.Add($ip)
-                        }
-                    } finally {
-                        $c.Dispose()
+                    if ($c.ConnectAsync($ip, $port).Wait($timeoutMs) -and $c.Connected) {
+                        $ip
                     }
-                } catch {
-                    Write-Debug "[Find-Yarbo] TCP probe error for ${ip}: $($_.Exception.Message)"
                 } finally {
-                    $semaphore.Release() | Out-Null
+                    $c.Dispose()
                 }
-            }.GetNewClosure())
-        $tasks.Add($task)
-    }
-    [System.Threading.Tasks.Task]::WhenAll($tasks.ToArray()).GetAwaiter().GetResult() | Out-Null
-
-    $candidates = @($candidateIps)
+            } catch {
+                Write-Debug "[Find-Yarbo] TCP probe error for ${ip}: $($_.Exception.Message)"
+            }
+        } -ThrottleLimit $ThrottleLimit | Where-Object { $null -ne $_ }
+    )
+    $candidates = @($tcpCandidates)
     Write-Verbose "[Find-Yarbo] TCP probe found $($candidates.Count) candidate(s)"
 
     if ($candidates.Count -eq 0) {
@@ -139,7 +144,8 @@ function Find-Yarbo {
         return
     }
 
-    # ── 3. MQTT discovery — confirm each candidate has a Yarbo heart_beat ─────
+    # ── 3. MQTT discovery — only brokers that publish Yarbo topics ─────────────
+    # Use C# YarboMqttListener so the message-received handler runs in-process (reliable).
     if ($null -eq $script:MqttAssembly) {
         Write-Warning "[Find-Yarbo] MQTTnet assembly not loaded. Returning TCP-only results with unknown SerialNumber."
         foreach ($ip in $candidates) {
@@ -151,79 +157,65 @@ function Find-Yarbo {
         return
     }
 
+    $listenerType = [PSYarbo.Mqtt.YarboMqttListener]
+    if (-not $listenerType) {
+        Write-Warning "[Find-Yarbo] YarboMqttListener not available. Returning TCP-only results."
+        foreach ($ip in $candidates) {
+            $r = [YarboRobot]::new()
+            $r.Broker = $ip
+            $r.Port = $Port
+            Write-Output $r
+        }
+        return
+    }
+
     $mqttTimeoutMs = [int](($TimeoutSeconds * 1000) * 0.6)  # 60% budget for MQTT
+    # Only subscribe to Yarbo device topics (snowbot/{SN}/device/...) — filters out non-Yarbo brokers
+    $yarboTopicFilters = @('snowbot/+/device/DeviceMSG', 'snowbot/+/device/data_feedback', 'snowbot/+/device/heart_beat')
 
+    $discovered = @{}
     foreach ($ip in $candidates) {
-        Write-Verbose "[Find-Yarbo] MQTT probe: connecting to ${ip}:${Port}"
+        Write-Verbose "[Find-Yarbo] MQTT probe: connecting to ${ip}:${Port} (Yarbo topics only)"
 
-        $factory = $null
-        $client = $null
-        $signal = [System.Threading.SemaphoreSlim]::new(0, 1)
-        $detectedSN = $null
-
+        $listener = $null
         try {
-            $factory = [System.Activator]::CreateInstance($script:MqttAssembly.GetType('MQTTnet.MqttFactory'))
-            $client = $factory.CreateMqttClient()
+            $listener = [PSYarbo.Mqtt.YarboMqttListener]::new()
+            # Anonymous client ID for discovery (matches python-yarbo)
+            $listener.Connect($ip, $Port, [string]::Empty, [TimeSpan]::FromSeconds(3))
+            $listener.Subscribe([string[]]$yarboTopicFilters)
 
-            $clientId = "PSYarbo-Discover-$([guid]::NewGuid().ToString('N').Substring(0,8))"
-            $options = $factory.CreateClientOptionsBuilder().WithTcpServer($ip, $Port).WithClientId($clientId).WithTimeout(
-                [TimeSpan]::FromSeconds(3)
-            ).Build()
-
-            $client.ConnectAsync($options, [System.Threading.CancellationToken]::None).GetAwaiter().GetResult() | Out-Null
-
-            # Subscribe to wildcard heart_beat
-            $subOpts = $factory.CreateSubscribeOptionsBuilder().WithTopicFilter('snowbot/+/device/heart_beat').Build()
-            $client.SubscribeAsync($subOpts, [System.Threading.CancellationToken]::None).GetAwaiter().GetResult() | Out-Null
-
-            # Capture first heart_beat message
-            $localSignal = $signal
-            $snRef = [ref]$detectedSN
-            $client.ApplicationMessageReceivedAsync.Add({
-                    param($ea)
-                    $seg = $ea.ApplicationMessage.PayloadSegment
-                    if ($null -ne $seg -and $seg.Count -gt 0) {
-                        $topicParts = $ea.ApplicationMessage.Topic -split '/'
-                        # topic = snowbot/{SN}/device/heart_beat — SN is index 1
-                        if ($topicParts.Count -ge 2 -and $topicParts[1] -ne '+') {
-                            $snRef.Value = $topicParts[1]
-                            try { $localSignal.Release() | Out-Null } catch { $null = $_ }
-                        }
+            $first = $listener.WaitForFirstMessage($mqttTimeoutMs)
+            if ($null -ne $first -and $first.Topic.Length -gt 0) {
+                # Topic: snowbot/{SN}/device/...
+                $parts = $first.Topic -split '/'
+                $sn = if ($parts.Count -ge 2 -and $parts[1] -ne '+') { $parts[1] } else { $null }
+                if ($sn -and -not $discovered.ContainsKey($sn)) {
+                    Write-Verbose "[Find-Yarbo] Discovered Yarbo SN=$sn at ${ip}:${Port} (topic: $($first.Topic))"
+                    $r = [YarboRobot]::new()
+                    $r.Broker = $ip
+                    $r.Port = $Port
+                    $r.SerialNumber = $sn
+                    $r.LastUpdated = [datetime]::UtcNow
+                    $discovered[$sn] = $r
+                } else {
+                    if ($sn) {
+                        Write-Verbose "[Find-Yarbo] ${ip}:${Port} — same device as already discovered (SN=$sn, skipped duplicate)"
+                    } else {
+                        Write-Verbose "[Find-Yarbo] ${ip}:${Port} — received topic without SN (skipped)"
                     }
-                    return [System.Threading.Tasks.Task]::CompletedTask
-                }.GetNewClosure())
-
-            # Wait for heart_beat
-            $gotHb = $signal.Wait($mqttTimeoutMs)
-
-            if ($gotHb -and $snRef.Value) {
-                Write-Verbose "[Find-Yarbo] Discovered Yarbo SN=$($snRef.Value) at ${ip}:${Port}"
-
-                # Attempt to parse state from heart_beat payload for richer YarboRobot
-                $r = [YarboRobot]::new()
-                $r.Broker = $ip
-                $r.Port = $Port
-                $r.SerialNumber = $snRef.Value
-                $r.LastUpdated = [datetime]::UtcNow
-                Write-Output $r
+                }
             } else {
-                Write-Verbose "[Find-Yarbo] ${ip}:${Port} — no Yarbo heart_beat received within ${TimeoutSeconds}s (skipped)"
+                Write-Verbose "[Find-Yarbo] ${ip}:${Port} — no Yarbo message within ${TimeoutSeconds}s (skipped)"
             }
         } catch {
             Write-Verbose "[Find-Yarbo] ${ip}:${Port} — MQTT connect failed: $($_.Exception.Message)"
         } finally {
-            if ($client) {
-                try {
-                    $client.DisconnectAsync(
-                        $factory.CreateClientDisconnectOptionsBuilder().Build(),
-                        [System.Threading.CancellationToken]::None
-                    ).GetAwaiter().GetResult() | Out-Null
-                } catch {
-                    Write-Debug "[Find-Yarbo] MQTT disconnect error (non-fatal): $($_.Exception.Message)"
-                }
-                try { if ($client -is [System.IDisposable]) { $client.Dispose() } } catch { $null = $_ }
+            if ($listener) {
+                try { $listener.Dispose() } catch { Write-Debug "[Find-Yarbo] Listener dispose: $($_.Exception.Message)" }
             }
-            $signal.Dispose()
         }
+    }
+    foreach ($r in $discovered.Values) {
+        Write-Output $r
     }
 }

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -166,20 +166,14 @@ function Find-Yarbo {
                 # Topic: snowbot/{SN}/device/...
                 $parts = $first.Topic -split '/'
                 $sn = if ($parts.Count -ge 2 -and $parts[1] -ne '+') { $parts[1] } else { $null }
-                if ($sn -and -not $discovered.ContainsKey($sn)) {
-                    Write-Verbose "[Find-Yarbo] Discovered Yarbo SN=$sn at ${ip}:${Port} (topic: $($first.Topic))"
-                    $r = [YarboRobot]::new()
-                    $r.Broker = $ip
-                    $r.Port = $Port
-                    $r.SerialNumber = $sn
-                    $r.LastUpdated = [datetime]::UtcNow
-                    $discovered[$sn] = $r
-                } else {
-                    if ($sn) {
-                        Write-Verbose "[Find-Yarbo] ${ip}:${Port} — same device as already discovered (SN=$sn, skipped duplicate)"
-                    } else {
-                        Write-Verbose "[Find-Yarbo] ${ip}:${Port} — received topic without SN (skipped)"
+                if ($sn) {
+                    if (-not $discovered.ContainsKey($sn)) {
+                        $discovered[$sn] = [System.Collections.Generic.List[hashtable]]::new()
                     }
+                    Write-Verbose "[Find-Yarbo] Discovered Yarbo SN=$sn at ${ip}:${Port} (topic: $($first.Topic))"
+                    $discovered[$sn].Add(@{ IP = $ip; Port = $Port; SerialNumber = $sn })
+                } else {
+                    Write-Verbose "[Find-Yarbo] ${ip}:${Port} — received topic without SN (skipped)"
                 }
             } else {
                 Write-Verbose "[Find-Yarbo] ${ip}:${Port} — no Yarbo message within ${TimeoutSeconds}s (skipped)"
@@ -192,7 +186,14 @@ function Find-Yarbo {
             }
         }
     }
-    foreach ($r in $discovered.Values) {
-        Write-Output $r
+    foreach ($endpoints in $discovered.Values) {
+        foreach ($ep in $endpoints) {
+            $r = [YarboRobot]::new()
+            $r.Broker = $ep.IP
+            $r.Port = $ep.Port
+            $r.SerialNumber = $ep.SerialNumber
+            $r.LastUpdated = [datetime]::UtcNow
+            Write-Output $r
+        }
     }
 }

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -83,31 +83,7 @@ function Find-Yarbo {
         $subnetsToScan = @($Subnet.Trim())
     }
 
-    $ipList = [System.Collections.Generic.List[string]]::new()
-    $remaining = $MaxHosts
-    foreach ($oneSubnet in $subnetsToScan) {
-        if ($remaining -le 0) { break }
-        $parts = $oneSubnet -split '/'
-        if ($parts.Count -lt 2) { continue }
-        $prefixLen = [int]$parts[1]
-        if ($prefixLen -lt 16 -or $prefixLen -gt 30) { continue }
-        $baseIp = [System.Net.IPAddress]::Parse($parts[0].Trim())
-        $baseBytes = $baseIp.GetAddressBytes()
-        [Array]::Reverse($baseBytes)
-        $hostBits = 32 - $prefixLen
-        $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
-        $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
-        $baseBytes = [System.BitConverter]::GetBytes($baseVal)
-        $maxInSubnet = [math]::Pow(2, $hostBits) - 2
-        $take = [math]::Min([int]$maxInSubnet, $remaining)
-        for ($i = 1; $i -le $take; $i++) {
-            $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
-            $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
-            [Array]::Reverse($newBytes)
-            $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())
-        }
-        $remaining -= $take
-    }
+    $ipList = @(Get-PSYarboSubnetIpList -Subnets $subnetsToScan -MaxHosts $MaxHosts)
     $hostCount = $ipList.Count
     Write-Verbose "[Find-Yarbo] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts for MQTT brokers on port $Port"
     if ($hostCount -gt 512) {
@@ -157,7 +133,7 @@ function Find-Yarbo {
         return
     }
 
-    $listenerType = [PSYarbo.Mqtt.YarboMqttListener]
+    $listenerType = 'PSYarbo.Mqtt.YarboMqttListener' -as [type]
     if (-not $listenerType) {
         Write-Warning "[Find-Yarbo] YarboMqttListener not available. Returning TCP-only results."
         foreach ($ip in $candidates) {

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -74,7 +74,7 @@ function Find-Yarbo {
     if ([string]::IsNullOrWhiteSpace($Subnet)) {
         $subnetsToScan = @(Get-PSYarboLocalSubnets)
         if ($subnetsToScan.Count -eq 0) {
-            $subnetsToScan = @('192.0.2.0/24')
+            $subnetsToScan = @('192.168.1.0/24')
             Write-Verbose "[Find-Yarbo] No local subnets detected; using fallback $($subnetsToScan[0])"
         } else {
             Write-Verbose "[Find-Yarbo] Using local subnets: $($subnetsToScan -join ', ')"

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -186,7 +186,9 @@ function Find-Yarbo {
             }
         }
     }
+    # One YarboRobot per device (SerialNumber); use first discovered endpoint per device
     foreach ($endpoints in $discovered.Values) {
+        if ($endpoints.Count -eq 0) { continue }
         $ep = $endpoints[0]
         $r = [YarboRobot]::new()
         $r.Broker = $ep.IP

--- a/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
+++ b/src/PSYarbo/Public/Connection/Find-Yarbo.ps1
@@ -71,7 +71,10 @@ function Find-Yarbo {
     )
 
     # ── 1. Resolve subnets to scan (local interfaces or -Subnet) ───────────────
-    if ([string]::IsNullOrWhiteSpace($Subnet)) {
+    $userProvidedSubnet = -not [string]::IsNullOrWhiteSpace($Subnet)
+    if ($userProvidedSubnet) {
+        $subnetsToScan = @($Subnet.Trim())
+    } else {
         $subnetsToScan = @(Get-PSYarboLocalSubnet)
         if ($subnetsToScan.Count -eq 0) {
             $subnetsToScan = @('192.168.1.0/24')
@@ -79,11 +82,9 @@ function Find-Yarbo {
         } else {
             Write-Verbose "[Find-Yarbo] Using local subnets: $($subnetsToScan -join ', ')"
         }
-    } else {
-        $subnetsToScan = @($Subnet.Trim())
     }
 
-    $ipList = @(Get-PSYarboSubnetIpList -Subnets $subnetsToScan -MaxHosts $MaxHosts)
+    $ipList = @(Get-PSYarboSubnetIpList -Subnets $subnetsToScan -MaxHosts $MaxHosts -ValidateUserInput:$userProvidedSubnet)
     $hostCount = $ipList.Count
     Write-Verbose "[Find-Yarbo] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts for MQTT brokers on port $Port"
     if ($hostCount -gt 512) {

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -97,7 +97,10 @@ function Find-YarboDevice {
     }
 
     # ── Resolve subnets to scan (local interfaces or -Subnet) ────────────────
-    if ([string]::IsNullOrWhiteSpace($Subnet)) {
+    $userProvidedSubnet = -not [string]::IsNullOrWhiteSpace($Subnet)
+    if ($userProvidedSubnet) {
+        $subnetsToScan = @($Subnet.Trim())
+    } else {
         $subnetsToScan = @(Get-PSYarboLocalSubnet)
         if ($subnetsToScan.Count -eq 0) {
             $subnetsToScan = @('192.168.1.0/24')
@@ -105,11 +108,9 @@ function Find-YarboDevice {
         } else {
             Write-Verbose "[Find-YarboDevice] Using local subnets: $($subnetsToScan -join ', ')"
         }
-    } else {
-        $subnetsToScan = @($Subnet.Trim())
     }
 
-    $ipList = @(Get-PSYarboSubnetIpList -Subnets $subnetsToScan -MaxHosts $MaxHosts)
+    $ipList = @(Get-PSYarboSubnetIpList -Subnets $subnetsToScan -MaxHosts $MaxHosts -ValidateUserInput:$userProvidedSubnet)
     $hostCount = $ipList.Count
     Write-Verbose "[Find-YarboDevice] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts"
     if ($hostCount -gt 512) {

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -239,11 +239,13 @@ function Find-YarboDevice {
     $bothPresent = $hasRover -and $hasDC
 
     # ── Console output (table + recommendation text) ────────────────────────
+    # Sort into try-order: recommended first, then others (primary/secondary failover).
+    $tryOrder = @($endpoints | Sort-Object { -not $_.Recommended })
     Write-Information ""
     Write-Information "Yarbo MQTT Endpoints Found:"
     Write-Information ""
     $i = 1
-    foreach ($ep in $endpoints) {
+    foreach ($ep in $tryOrder) {
         $rec = if ($ep.Recommended) { '  ⭐ Recommended' } else { '' }
         $mac = if ($ep.MacAddress) { $ep.MacAddress } else { '(unknown – Rover/DC unclear)' }
         Write-Information ("  {0,2}  {1,-15}  {2,-5}  {3,-17}  {4,-10}{5}" -f $i, $ep.IPAddress, $ep.Path, $mac, $ep.Status, $rec)
@@ -265,7 +267,6 @@ function Find-YarboDevice {
     Write-Information ""
 
     # Output in try-order: recommended first, then others (primary/secondary failover).
-    $tryOrder = @($endpoints | Sort-Object { -not $_.Recommended })
     foreach ($ep in $tryOrder) {
         Write-Output $ep
     }

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -60,9 +60,9 @@ function Find-YarboDevice {
         [Parameter()]
         [AllowEmptyString()]
         [ValidateScript({
-            if ([string]::IsNullOrEmpty($_)) { return $true }
-            $_ -match '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
-        })]
+                if ([string]::IsNullOrEmpty($_)) { return $true }
+                $_ -match '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+            })]
         [string]$Subnet = '',
 
         [Parameter()]
@@ -96,7 +96,7 @@ function Find-YarboDevice {
 
     # ── Resolve subnets to scan (local interfaces or -Subnet) ────────────────
     if ([string]::IsNullOrWhiteSpace($Subnet)) {
-        $subnetsToScan = @(Get-PSYarboLocalSubnets)
+        $subnetsToScan = @(Get-PSYarboLocalSubnet)
         if ($subnetsToScan.Count -eq 0) {
             $subnetsToScan = @('192.168.1.0/24')
             Write-Verbose "[Find-YarboDevice] No local subnets detected; using fallback $($subnetsToScan[0])"
@@ -111,7 +111,7 @@ function Find-YarboDevice {
     $hostCount = $ipList.Count
     Write-Verbose "[Find-YarboDevice] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts"
     if ($hostCount -gt 512) {
-        Write-Warning "Find-YarboDevice: Scanning $hostCount hosts; this may be slow. Use -MaxHosts to scan more (will take longer), or reduce -MaxHosts for a quicker scan."
+        Write-Warning "Find-YarboDevice: Scanning $hostCount hosts; this may be slow. Consider using a more specific -Subnet or reducing -MaxHosts to speed up the scan."
     }
 
     # ── TCP probe ────────────────────────────────────────────────────────────

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -107,31 +107,7 @@ function Find-YarboDevice {
         $subnetsToScan = @($Subnet.Trim())
     }
 
-    $ipList = [System.Collections.Generic.List[string]]::new()
-    $remaining = $MaxHosts
-    foreach ($oneSubnet in $subnetsToScan) {
-        if ($remaining -le 0) { break }
-        $parts = $oneSubnet -split '/'
-        if ($parts.Count -lt 2) { continue }
-        $prefixLen = [int]$parts[1]
-        if ($prefixLen -lt 16 -or $prefixLen -gt 30) { continue }
-        $baseIp = [System.Net.IPAddress]::Parse($parts[0].Trim())
-        $baseBytes = $baseIp.GetAddressBytes()
-        [Array]::Reverse($baseBytes)
-        $hostBits = 32 - $prefixLen
-        $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
-        $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
-        $baseBytes = [System.BitConverter]::GetBytes($baseVal)
-        $maxInSubnet = [math]::Pow(2, $hostBits) - 2
-        $take = [math]::Min([int]$maxInSubnet, $remaining)
-        for ($i = 1; $i -le $take; $i++) {
-            $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
-            $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
-            [Array]::Reverse($newBytes)
-            $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())
-        }
-        $remaining -= $take
-    }
+    $ipList = @(Get-PSYarboSubnetIpList -Subnets $subnetsToScan -MaxHosts $MaxHosts)
     $hostCount = $ipList.Count
     Write-Verbose "[Find-YarboDevice] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts"
     if ($hostCount -gt 512) {
@@ -166,7 +142,8 @@ function Find-YarboDevice {
     $yarboTopicFilters = @('snowbot/+/device/DeviceMSG', 'snowbot/+/device/data_feedback', 'snowbot/+/device/heart_beat')
     $mqttTimeoutMs = [int](($TimeoutSeconds * 1000) * 0.6)
 
-    if ($null -eq $script:MqttAssembly -or -not ([PSYarbo.Mqtt.YarboMqttListener])) {
+    $listenerType = 'PSYarbo.Mqtt.YarboMqttListener' -as [type]
+    if ($null -eq $script:MqttAssembly -or -not $listenerType) {
         Write-Warning "[Find-YarboDevice] MQTTnet/YarboMqttListener not available. Cannot verify Yarbo brokers."
         return
     }

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -191,18 +191,13 @@ function Find-YarboDevice {
         Invoke-ArpPrime -IPAddress $v.IP
     }
     $endpoints = [System.Collections.Generic.List[YarboEndpoint]]::new()
-    $hasRover = $false
-    $hasDC = $false
     foreach ($v in $verified) {
         $mac = Get-MacForIp -IPAddress $v.IP
         $isDC = $false
         if ($mac) {
             $isDC = Test-LocallyAdministeredMac -Mac $mac
-            if ($isDC) { $hasDC = $true } else { $hasRover = $true }
-        } else {
-            # Unknown MAC: treat as Rover to avoid wrongly recommending
-            $hasRover = $true
         }
+        # Unknown MAC: treat as Rover to avoid wrongly recommending
         $path = if ($isDC) { 'DC' } else { 'Rover' }
         $ep = [YarboEndpoint]::new()
         $ep.IPAddress = $v.IP
@@ -239,7 +234,17 @@ function Find-YarboDevice {
             foreach ($r in $rovers) { $r.Recommended = ($r -eq $toRecommend) }
         }
     }
-    $bothPresent = $hasRover -and $hasDC
+    # Only show "Both endpoints reach the same broker" when at least one device has both Rover and DC (per SerialNumber).
+    $bothPresentForAnyDevice = $false
+    foreach ($sn in $bySerial.Keys) {
+        $group = $bySerial[$sn]
+        $hasDc = (@($group | Where-Object { $_.Path -eq 'DC' }).Count) -gt 0
+        $hasRoverInGroup = (@($group | Where-Object { $_.Path -eq 'Rover' }).Count) -gt 0
+        if ($hasDc -and $hasRoverInGroup) {
+            $bothPresentForAnyDevice = $true
+            break
+        }
+    }
 
     # ── Console output (table + recommendation text) ────────────────────────
     # Sort into try-order: recommended first, then others (primary/secondary failover).
@@ -254,7 +259,7 @@ function Find-YarboDevice {
         Write-Information ("  {0,2}  {1,-15}  {2,-5}  {3,-17}  {4,-10}{5}" -f $i, $ep.IPAddress, $ep.Path, $mac, $ep.Status, $rec)
         $i++
     }
-    if ($bothPresent) {
+    if ($bothPresentForAnyDevice) {
         Write-Information ""
         Write-Information "Both endpoints reach the same MQTT broker on the Rover."
         Write-Information "The DC path is recommended — it stays connected via HaLow"

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -39,7 +39,7 @@ function Find-YarboDevice {
     Find-YarboDevice
 
 .EXAMPLE
-    Find-YarboDevice -Subnet 192.168.1.0/24 -TimeoutSeconds 10
+    Find-YarboDevice -Subnet 192.0.2.0/24 -TimeoutSeconds 10
 
 .EXAMPLE
     # Primary/secondary for failover (e.g. Home Assistant): try first, then second if unreachable.
@@ -98,7 +98,7 @@ function Find-YarboDevice {
     if ([string]::IsNullOrWhiteSpace($Subnet)) {
         $subnetsToScan = @(Get-PSYarboLocalSubnets)
         if ($subnetsToScan.Count -eq 0) {
-            $subnetsToScan = @('192.168.0.0/23')
+            $subnetsToScan = @('192.0.2.0/24')
             Write-Verbose "[Find-YarboDevice] No local subnets detected; using fallback $($subnetsToScan[0])"
         } else {
             Write-Verbose "[Find-YarboDevice] Using local subnets: $($subnetsToScan -join ', ')"

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -1,0 +1,291 @@
+function Find-YarboDevice {
+    <#
+.SYNOPSIS
+    Discovers Yarbo MQTT endpoints and labels them as Rover vs DC with a recommendation.
+
+.DESCRIPTION
+    Scans the local network for Yarbo MQTT brokers (port 1883), verifies each via
+    snowbot/+/device/ heartbeat topics, then resolves MAC addresses and classifies
+    each endpoint as Rover or DC using the MAC address:
+    - Rover = direct WiFi to the mower (MAC is not locally administered).
+    - DC = base station / data center bridge (MAC is locally administered).
+    When the MAC cannot be resolved, the endpoint is listed as Rover and MAC shows
+    "(unknown)"; classification is then uncertain. If both IPs show the same MAC
+    (e.g. traffic via the DC port-forward) or no locally-administered MAC is seen,
+    we cannot tell Rover from DC — use both addresses in failover order instead.
+
+    Output order is try-order: recommended first, then others. Use the first address
+    as primary (e.g. in Home Assistant); if it is unreachable, try the next (like
+    primary/secondary DNS).
+
+    Optionally tries DNS hostname "YARBO" as a fast-path for the DC before scanning.
+
+.PARAMETER Subnet
+    Network subnet(s) to scan in CIDR notation. When not specified, scans all networks this machine has an IP on (LAN, Wi‑Fi, etc.).
+
+.PARAMETER TimeoutSeconds
+    How long to wait per broker for a Yarbo message. Default: 5.
+
+.PARAMETER Port
+    MQTT port. Default: 1883.
+
+.PARAMETER MaxHosts
+    Maximum hosts to scan. Default: 512 (so a /23 is fully scanned).
+
+.PARAMETER ThrottleLimit
+    Concurrent TCP probe tasks. Default: 64.
+
+.EXAMPLE
+    Find-YarboDevice
+
+.EXAMPLE
+    Find-YarboDevice -Subnet 192.168.1.0/24 -TimeoutSeconds 10
+
+.EXAMPLE
+    # Primary/secondary for failover (e.g. Home Assistant): try first, then second if unreachable.
+    $endpoints = Find-YarboDevice
+    $primary = $endpoints[0].IPAddress; $secondary = $endpoints[1].IPAddress
+
+.OUTPUTS
+    YarboEndpoint[] with IPAddress, Port, Path (Rover|DC), MacAddress, Recommended, Hostname, SerialNumber, Status.
+
+.LINK
+    Find-Yarbo
+    Connect-Yarbo
+    https://github.com/markus-lassfolk/PSYarbo/issues/30
+#>
+    [CmdletBinding()]
+    [OutputType([YarboEndpoint])]
+    param(
+        [Parameter()]
+        [AllowEmptyString()]
+        [ValidateScript({
+            if ([string]::IsNullOrEmpty($_)) { return $true }
+            $_ -match '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+        })]
+        [string]$Subnet = '',
+
+        [Parameter()]
+        [ValidateRange(1, 120)]
+        [int]$TimeoutSeconds = 5,
+
+        [Parameter()]
+        [int]$Port = 1883,
+
+        [Parameter()]
+        [ValidateRange(1, 65534)]
+        [int]$MaxHosts = 512,
+
+        [Parameter()]
+        [ValidateRange(1, 256)]
+        [int]$ThrottleLimit = 64
+    )
+
+    # ── DNS fast-path: try hostname YARBO (DC may register via DHCP) ─────────
+    $dnsFirst = [System.Collections.Generic.List[string]]::new()
+    try {
+        $resolved = [System.Net.Dns]::GetHostAddresses('YARBO')
+        foreach ($a in $resolved) {
+            if ($a.AddressFamily -eq 'InterNetwork') {
+                $dnsFirst.Add($a.ToString())
+            }
+        }
+    } catch {
+        Write-Debug "[Find-YarboDevice] DNS YARBO lookup: $($_.Exception.Message)"
+    }
+
+    # ── Resolve subnets to scan (local interfaces or -Subnet) ────────────────
+    if ([string]::IsNullOrWhiteSpace($Subnet)) {
+        $subnetsToScan = @(Get-PSYarboLocalSubnets)
+        if ($subnetsToScan.Count -eq 0) {
+            $subnetsToScan = @('192.168.0.0/23')
+            Write-Verbose "[Find-YarboDevice] No local subnets detected; using fallback $($subnetsToScan[0])"
+        } else {
+            Write-Verbose "[Find-YarboDevice] Using local subnets: $($subnetsToScan -join ', ')"
+        }
+    } else {
+        $subnetsToScan = @($Subnet.Trim())
+    }
+
+    $ipList = [System.Collections.Generic.List[string]]::new()
+    $remaining = $MaxHosts
+    foreach ($oneSubnet in $subnetsToScan) {
+        if ($remaining -le 0) { break }
+        $parts = $oneSubnet -split '/'
+        if ($parts.Count -lt 2) { continue }
+        $prefixLen = [int]$parts[1]
+        if ($prefixLen -lt 16 -or $prefixLen -gt 30) { continue }
+        $baseIp = [System.Net.IPAddress]::Parse($parts[0].Trim())
+        $baseBytes = $baseIp.GetAddressBytes()
+        [Array]::Reverse($baseBytes)
+        $hostBits = 32 - $prefixLen
+        $baseVal = [System.BitConverter]::ToUInt32($baseBytes, 0)
+        $baseVal = [uint32]($baseVal -band ([uint32]::MaxValue -shl $hostBits))
+        $baseBytes = [System.BitConverter]::GetBytes($baseVal)
+        $maxInSubnet = [math]::Pow(2, $hostBits) - 2
+        $take = [math]::Min([int]$maxInSubnet, $remaining)
+        for ($i = 1; $i -le $take; $i++) {
+            $ipVal = ([System.BitConverter]::ToUInt32($baseBytes, 0)) + $i
+            $newBytes = [System.BitConverter]::GetBytes([uint32]$ipVal)
+            [Array]::Reverse($newBytes)
+            $ipList.Add([System.Net.IPAddress]::new($newBytes).ToString())
+        }
+        $remaining -= $take
+    }
+    $hostCount = $ipList.Count
+    Write-Verbose "[Find-YarboDevice] Scanning $($subnetsToScan.Count) subnet(s), $hostCount hosts"
+    if ($hostCount -gt 512) {
+        Write-Warning "Find-YarboDevice: Scanning $hostCount hosts; this may be slow. Use -MaxHosts to scan more (will take longer), or reduce -MaxHosts for a quicker scan."
+    }
+
+    # ── TCP probe ────────────────────────────────────────────────────────────
+    $tcpTimeoutMs = [int]($TimeoutSeconds * 1000 * 0.4)
+    $tcpCandidates = @(
+        $ipList | ForEach-Object -Parallel {
+            $ip = $_
+            $port = $using:Port
+            $timeoutMs = $using:tcpTimeoutMs
+            try {
+                $c = [System.Net.Sockets.TcpClient]::new()
+                try {
+                    if ($c.ConnectAsync($ip, $port).Wait($timeoutMs) -and $c.Connected) { $ip }
+                } finally { $c.Dispose() }
+            } catch { Write-Debug "[Find-YarboDevice] TCP $ip : $($_.Exception.Message)" }
+        } -ThrottleLimit $ThrottleLimit | Where-Object { $null -ne $_ }
+    )
+    $candidates = @($dnsFirst) + @($tcpCandidates) | Select-Object -Unique
+    Write-Verbose "[Find-YarboDevice] Candidates: $($candidates.Count)"
+
+    if ($candidates.Count -eq 0) {
+        Write-Verbose "[Find-YarboDevice] No MQTT brokers found."
+        return
+    }
+
+    # ── MQTT verify and collect (IP, SerialNumber, Hostname) ───────────────────
+    $verified = [System.Collections.Generic.List[hashtable]]::new()
+    $yarboTopicFilters = @('snowbot/+/device/DeviceMSG', 'snowbot/+/device/data_feedback', 'snowbot/+/device/heart_beat')
+    $mqttTimeoutMs = [int](($TimeoutSeconds * 1000) * 0.6)
+
+    if ($null -eq $script:MqttAssembly -or -not ([PSYarbo.Mqtt.YarboMqttListener])) {
+        Write-Warning "[Find-YarboDevice] MQTTnet/YarboMqttListener not available. Cannot verify Yarbo brokers."
+        return
+    }
+
+    foreach ($ip in $candidates) {
+        $hostname = if ($dnsFirst -contains $ip) { 'YARBO' } else { $null }
+        $listener = $null
+        try {
+            $listener = [PSYarbo.Mqtt.YarboMqttListener]::new()
+            $listener.Connect($ip, $Port, [string]::Empty, [TimeSpan]::FromSeconds(3))
+            $listener.Subscribe([string[]]$yarboTopicFilters)
+            $first = $listener.WaitForFirstMessage($mqttTimeoutMs)
+            if ($null -ne $first -and $first.Topic.Length -gt 0) {
+                $topicParts = $first.Topic -split '/'
+                $sn = if ($topicParts.Count -ge 2 -and $topicParts[1] -ne '+') { $topicParts[1] } else { $null }
+                if ($sn) {
+                    $verified.Add(@{ IP = $ip; Port = $Port; SerialNumber = $sn; Hostname = $hostname })
+                    Write-Verbose "[Find-YarboDevice] Verified Yarbo at ${ip}:${Port} SN=$sn"
+                }
+            }
+        } catch {
+            Write-Verbose "[Find-YarboDevice] ${ip}:${Port} — $($_.Exception.Message)"
+        } finally {
+            if ($listener) {
+                try { $listener.Dispose() } catch {
+                    Write-Debug "[Find-YarboDevice] Listener dispose: $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+
+    if ($verified.Count -eq 0) {
+        Write-Verbose "[Find-YarboDevice] No Yarbo brokers responded with device topics."
+        return
+    }
+
+    # ── Enrich with MAC, Path (Rover/DC), Recommended ────────────────────────
+    # Prime ARP so we can resolve MAC (Rover vs DC is determined by locally-administered MAC).
+    foreach ($v in $verified) {
+        Invoke-ArpPrime -IPAddress $v.IP
+    }
+    $endpoints = [System.Collections.Generic.List[YarboEndpoint]]::new()
+    $hasRover = $false
+    $hasDC = $false
+    foreach ($v in $verified) {
+        $mac = Get-MacForIp -IPAddress $v.IP
+        $isDC = $false
+        if ($mac) {
+            $isDC = Test-LocallyAdministeredMac -Mac $mac
+            if ($isDC) { $hasDC = $true } else { $hasRover = $true }
+        } else {
+            # Unknown MAC: treat as Rover to avoid wrongly recommending
+            $hasRover = $true
+        }
+        $path = if ($isDC) { 'DC' } else { 'Rover' }
+        $ep = [YarboEndpoint]::new()
+        $ep.IPAddress = $v.IP
+        $ep.Port = $v.Port
+        $ep.Path = $path
+        $ep.MacAddress = $mac ?? ''
+        $ep.Hostname = $v.Hostname ?? ''
+        $ep.SerialNumber = $v.SerialNumber ?? ''
+        $ep.Status = 'Connected'
+        $endpoints.Add($ep)
+    }
+
+    # Recommended: at most one per device (SerialNumber). Prefer DC; else one Rover (e.g. first or hostname YARBO).
+    $bySerial = @{}
+    foreach ($ep in $endpoints) {
+        $sn = $ep.SerialNumber ?? ''
+        if (-not $bySerial.ContainsKey($sn)) { $bySerial[$sn] = [System.Collections.Generic.List[YarboEndpoint]]::new() }
+        $bySerial[$sn].Add($ep)
+    }
+    foreach ($sn in $bySerial.Keys) {
+        $group = $bySerial[$sn]
+        $dcs = @($group | Where-Object { $_.Path -eq 'DC' })
+        $rovers = @($group | Where-Object { $_.Path -eq 'Rover' })
+        if ($dcs.Count -gt 0) {
+            $dcs[0].Recommended = $true
+            foreach ($i in 1..($dcs.Count - 1)) { $dcs[$i].Recommended = $false }
+            foreach ($r in $rovers) { $r.Recommended = $false }
+        } else {
+            # No DC: recommend exactly one Rover (prefer hostname YARBO, else first)
+            $toRecommend = $rovers | Where-Object { $_.Hostname -eq 'YARBO' } | Select-Object -First 1
+            if (-not $toRecommend) { $toRecommend = $rovers[0] }
+            foreach ($r in $rovers) { $r.Recommended = ($r -eq $toRecommend) }
+        }
+    }
+    $bothPresent = $hasRover -and $hasDC
+
+    # ── Console output (table + recommendation text) ────────────────────────
+    Write-Host ""
+    Write-Host "Yarbo MQTT Endpoints Found:"
+    Write-Host ""
+    $i = 1
+    foreach ($ep in $endpoints) {
+        $rec = if ($ep.Recommended) { '  ⭐ Recommended' } else { '' }
+        $mac = if ($ep.MacAddress) { $ep.MacAddress } else { '(unknown – Rover/DC unclear)' }
+        Write-Host ("  {0,2}  {1,-15}  {2,-5}  {3,-17}  {4,-10}{5}" -f $i, $ep.IPAddress, $ep.Path, $mac, $ep.Status, $rec)
+        $i++
+    }
+    if ($bothPresent) {
+        Write-Host ""
+        Write-Host "Both endpoints reach the same MQTT broker on the Rover."
+        Write-Host "The DC path is recommended — it stays connected via HaLow"
+        Write-Host "when the rover is outside WiFi range."
+    } elseif ($endpoints.Count -eq 1) {
+        Write-Host ""
+        Write-Host "Single endpoint found; use this address to connect."
+    } elseif ($endpoints.Count -gt 1) {
+        Write-Host ""
+        Write-Host "For failover (e.g. Home Assistant), use the recommended address first;"
+        Write-Host "if unreachable, try the other(s). Output order is try-order."
+    }
+    Write-Host ""
+
+    # Output in try-order: recommended first, then others (primary/secondary failover).
+    $tryOrder = @($endpoints | Sort-Object { -not $_.Recommended })
+    foreach ($ep in $tryOrder) {
+        Write-Output $ep
+    }
+}

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -246,7 +246,9 @@ function Find-YarboDevice {
         $rovers = @($group | Where-Object { $_.Path -eq 'Rover' })
         if ($dcs.Count -gt 0) {
             $dcs[0].Recommended = $true
-            foreach ($i in 1..($dcs.Count - 1)) { $dcs[$i].Recommended = $false }
+            if ($dcs.Count -gt 1) {
+                foreach ($i in 1..($dcs.Count - 1)) { $dcs[$i].Recommended = $false }
+            }
             foreach ($r in $rovers) { $r.Recommended = $false }
         } else {
             # No DC: recommend exactly one Rover (prefer hostname YARBO, else first)

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -81,6 +81,8 @@ function Find-YarboDevice {
         [int]$ThrottleLimit = 64
     )
 
+    $InformationPreference = 'Continue'
+
     # ── DNS fast-path: try hostname YARBO (DC may register via DHCP) ─────────
     $dnsFirst = [System.Collections.Generic.List[string]]::new()
     try {
@@ -237,30 +239,30 @@ function Find-YarboDevice {
     $bothPresent = $hasRover -and $hasDC
 
     # ── Console output (table + recommendation text) ────────────────────────
-    Write-Host ""
-    Write-Host "Yarbo MQTT Endpoints Found:"
-    Write-Host ""
+    Write-Information ""
+    Write-Information "Yarbo MQTT Endpoints Found:"
+    Write-Information ""
     $i = 1
     foreach ($ep in $endpoints) {
         $rec = if ($ep.Recommended) { '  ⭐ Recommended' } else { '' }
         $mac = if ($ep.MacAddress) { $ep.MacAddress } else { '(unknown – Rover/DC unclear)' }
-        Write-Host ("  {0,2}  {1,-15}  {2,-5}  {3,-17}  {4,-10}{5}" -f $i, $ep.IPAddress, $ep.Path, $mac, $ep.Status, $rec)
+        Write-Information ("  {0,2}  {1,-15}  {2,-5}  {3,-17}  {4,-10}{5}" -f $i, $ep.IPAddress, $ep.Path, $mac, $ep.Status, $rec)
         $i++
     }
     if ($bothPresent) {
-        Write-Host ""
-        Write-Host "Both endpoints reach the same MQTT broker on the Rover."
-        Write-Host "The DC path is recommended — it stays connected via HaLow"
-        Write-Host "when the rover is outside WiFi range."
+        Write-Information ""
+        Write-Information "Both endpoints reach the same MQTT broker on the Rover."
+        Write-Information "The DC path is recommended — it stays connected via HaLow"
+        Write-Information "when the rover is outside WiFi range."
     } elseif ($endpoints.Count -eq 1) {
-        Write-Host ""
-        Write-Host "Single endpoint found; use this address to connect."
+        Write-Information ""
+        Write-Information "Single endpoint found; use this address to connect."
     } elseif ($endpoints.Count -gt 1) {
-        Write-Host ""
-        Write-Host "For failover (e.g. Home Assistant), use the recommended address first;"
-        Write-Host "if unreachable, try the other(s). Output order is try-order."
+        Write-Information ""
+        Write-Information "For failover (e.g. Home Assistant), use the recommended address first;"
+        Write-Information "if unreachable, try the other(s). Output order is try-order."
     }
-    Write-Host ""
+    Write-Information ""
 
     # Output in try-order: recommended first, then others (primary/secondary failover).
     $tryOrder = @($endpoints | Sort-Object { -not $_.Recommended })

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -98,7 +98,7 @@ function Find-YarboDevice {
     if ([string]::IsNullOrWhiteSpace($Subnet)) {
         $subnetsToScan = @(Get-PSYarboLocalSubnets)
         if ($subnetsToScan.Count -eq 0) {
-            $subnetsToScan = @('192.0.2.0/24')
+            $subnetsToScan = @('192.168.1.0/24')
             Write-Verbose "[Find-YarboDevice] No local subnets detected; using fallback $($subnetsToScan[0])"
         } else {
             Write-Verbose "[Find-YarboDevice] Using local subnets: $($subnetsToScan -join ', ')"

--- a/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
+++ b/src/PSYarbo/Public/Connection/Find-YarboDevice.ps1
@@ -81,7 +81,9 @@ function Find-YarboDevice {
         [int]$ThrottleLimit = 64
     )
 
-    $InformationPreference = 'Continue'
+    if (-not $PSBoundParameters.ContainsKey('InformationAction')) {
+        $InformationPreference = 'Continue'
+    }
 
     # ── DNS fast-path: try hostname YARBO (DC may register via DHCP) ─────────
     $dnsFirst = [System.Collections.Generic.List[string]]::new()

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -44,7 +44,7 @@ function Invoke-YarboMqttSniff {
         throw "MQTTnet not loaded. Run build/Install-Dependencies.ps1 first."
     }
 
-    $listenerType = [PSYarbo.Mqtt.YarboMqttListener]
+    $listenerType = 'PSYarbo.Mqtt.YarboMqttListener' -as [type]
     if (-not $listenerType) {
         throw "YarboMqttListener not available. Ensure PSYarbo module loaded correctly."
     }

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -51,6 +51,9 @@ function Invoke-YarboMqttSniff {
 
     # Only subscribe to Yarbo topics so we only see Yarbo MQTT packages (unless -AllTopics)
     $topicFilters = if ($AllTopics) { @('#') } else { @('snowbot/#') }
+    if ($SelfTest -and -not $AllTopics) {
+        $topicFilters += 'PSYarbo/selftest'
+    }
     $filterDesc = if ($AllTopics) { 'all topics (#)' } else { 'Yarbo only (snowbot/#)' }
 
     $listener = $null

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Listen to MQTT messages from a broker (Yarbo topics by default).
+
+.DESCRIPTION
+    Connects to the given broker and listens for MQTT messages. By default
+    subscribes only to snowbot/# so you only see Yarbo robot traffic; use
+    -AllTopics to subscribe to # (all topics) for troubleshooting.
+
+.PARAMETER Broker
+    Broker IP or hostname.
+
+.PARAMETER Port
+    MQTT port. Default 1883.
+
+.PARAMETER DurationSeconds
+    How long to listen. Default 15.
+
+.PARAMETER AllTopics
+    If set, subscribe to # (all topics). Default is snowbot/# (Yarbo only).
+
+.PARAMETER SelfTest
+    If set, publish a test message to PSYarbo/selftest and confirm it is received.
+
+.PARAMETER LogPath
+    If set, append every received message line to this file.
+
+.OUTPUTS
+    PSCustomObject[] with Topic, PayloadBytes, At (timestamp).
+#>
+function Invoke-YarboMqttSniff {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Broker,
+        [int]$Port = 1883,
+        [int]$DurationSeconds = 15,
+        [switch]$AllTopics,
+        [switch]$SelfTest,
+        [string]$LogPath
+    )
+
+    if (-not $script:MqttAssembly) {
+        throw "MQTTnet not loaded. Run build/Install-Dependencies.ps1 first."
+    }
+
+    $listenerType = [PSYarbo.Mqtt.YarboMqttListener]
+    if (-not $listenerType) {
+        throw "YarboMqttListener not available. Ensure PSYarbo module loaded correctly."
+    }
+
+    # Only subscribe to Yarbo topics so we only see Yarbo MQTT packages (unless -AllTopics)
+    $topicFilters = if ($AllTopics) { @('#') } else { @('snowbot/#') }
+    $filterDesc = if ($AllTopics) { 'all topics (#)' } else { 'Yarbo only (snowbot/#)' }
+
+    $listener = $null
+    try {
+        $listener = [PSYarbo.Mqtt.YarboMqttListener]::new()
+        $clientId = "PSYarbo-Sniff-$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+        Write-Host "Connecting to ${Broker}:${Port} (filter: $filterDesc) ..."
+        $listener.Connect($Broker, $Port, $clientId, [TimeSpan]::FromSeconds(5))
+        $listener.Subscribe([string[]]$topicFilters)
+        Write-Host "Listening for ${DurationSeconds}s ..."
+
+        if ($SelfTest) {
+            Write-Host "Self-test: publishing to PSYarbo/selftest ..."
+            $listener.Publish('PSYarbo/selftest', [System.Text.Encoding]::UTF8.GetBytes('hello'))
+            Start-Sleep -Seconds 2
+        }
+
+        Start-Sleep -Seconds $DurationSeconds
+
+        $received = $listener.GetReceivedMessages()
+        $all = @(
+            foreach ($msg in $received) {
+                $len = if ($msg.Payload) { $msg.Payload.Length } else { 0 }
+                $at = [datetime]::UtcNow
+                Write-Host "[MQTT] $($msg.Topic) ($len bytes)"
+                if ($LogPath) {
+                    try {
+                        [System.IO.File]::AppendAllText($LogPath, "[$(Get-Date -Format 'o')] $($msg.Topic) ($len bytes)`n")
+                    } catch { $null = $_ }
+                }
+                [PSCustomObject]@{ Topic = $msg.Topic; PayloadBytes = $len; At = $at }
+            }
+        )
+
+        if ($SelfTest) {
+            $selftestCount = @($all | Where-Object { $_.Topic -eq 'PSYarbo/selftest' }).Count
+            Write-Host "Self-test: received $selftestCount message(s) on PSYarbo/selftest (expected 1)."
+        }
+
+        Write-Host ""
+        Write-Host "=== Sniff summary: $($all.Count) messages ==="
+        if ($all.Count -gt 0) {
+            $all | Group-Object -Property Topic | Sort-Object Count -Descending | ForEach-Object {
+                $sample = $_.Group[0]
+                Write-Host "  $($_.Count)x $($_.Name) ($($sample.PayloadBytes) bytes sample)"
+            }
+        } else {
+            Write-Host "  No messages received. Ensure the broker is a Yarbo MQTT broker and the robot is publishing."
+        }
+        return $all
+    } finally {
+        if ($listener) {
+            try { $listener.Dispose() } catch { $null = $_ }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -6,6 +6,7 @@
     Connects to the given broker and listens for MQTT messages. By default
     subscribes only to snowbot/# so you only see Yarbo robot traffic; use
     -AllTopics to subscribe to # (all topics) for troubleshooting.
+    Use -RecordPath to save full payloads for later analysis (e.g. coverage report).
 
 .PARAMETER Broker
     Broker IP or hostname.
@@ -14,7 +15,7 @@
     MQTT port. Default 1883.
 
 .PARAMETER DurationSeconds
-    How long to listen. Default 15.
+    How long to listen. Default 15. Use 60 for a one-minute recording.
 
 .PARAMETER AllTopics
     If set, subscribe to # (all topics). Default is snowbot/# (Yarbo only).
@@ -24,6 +25,10 @@
 
 .PARAMETER LogPath
     If set, append every received message line to this file.
+
+.PARAMETER RecordPath
+    If set, save a JSON recording of all messages (Topic, PayloadBase64, Index) to this file.
+    Use with Get-YarboMqttRecordingReport to see topic coverage vs. cmdlets.
 
 .OUTPUTS
     PSCustomObject[] with Topic, PayloadBytes, At (timestamp).
@@ -37,7 +42,8 @@ function Invoke-YarboMqttSniff {
         [int]$DurationSeconds = 15,
         [switch]$AllTopics,
         [switch]$SelfTest,
-        [string]$LogPath
+        [string]$LogPath,
+        [string]$RecordPath
     )
 
     if (-not $script:MqttAssembly) {
@@ -64,6 +70,7 @@ function Invoke-YarboMqttSniff {
         $listener.Connect($Broker, $Port, $clientId, [TimeSpan]::FromSeconds(5))
         $listener.Subscribe([string[]]$topicFilters)
         Write-Host "Listening for ${DurationSeconds}s ..."
+        $captureStart = [datetime]::UtcNow
 
         if ($SelfTest) {
             Write-Host "Self-test: publishing to PSYarbo/selftest ..."
@@ -74,19 +81,39 @@ function Invoke-YarboMqttSniff {
         Start-Sleep -Seconds $DurationSeconds
 
         $received = $listener.GetReceivedMessages()
-        $all = @(
-            foreach ($msg in $received) {
-                $len = if ($msg.Payload) { $msg.Payload.Length } else { 0 }
-                $at = [datetime]::UtcNow
-                Write-Host "[MQTT] $($msg.Topic) ($len bytes)"
-                if ($LogPath) {
-                    try {
-                        [System.IO.File]::AppendAllText($LogPath, "[$(Get-Date -Format 'o')] $($msg.Topic) ($len bytes)`n")
-                    } catch { $null = $_ }
-                }
-                [PSCustomObject]@{ Topic = $msg.Topic; PayloadBytes = $len; At = $at }
+        $all = [System.Collections.Generic.List[PSCustomObject]]::new()
+        $recordMessages = [System.Collections.Generic.List[PSCustomObject]]::new()
+        for ($i = 0; $i -lt $received.Count; $i++) {
+            $msg = $received[$i]
+            $len = if ($msg.Payload) { $msg.Payload.Length } else { 0 }
+            $at = $captureStart.AddMilliseconds($i)
+            Write-Host "[MQTT] $($msg.Topic) ($len bytes)"
+            if ($LogPath) {
+                try {
+                    [System.IO.File]::AppendAllText($LogPath, "[$(Get-Date -Format 'o')] $($msg.Topic) ($len bytes)`n")
+                } catch { $null = $_ }
             }
-        )
+            $all.Add([PSCustomObject]@{ Topic = $msg.Topic; PayloadBytes = $len; At = $at })
+            if ($RecordPath -and $msg.Payload) {
+                $b64 = [Convert]::ToBase64String($msg.Payload)
+                $recordMessages.Add([PSCustomObject]@{ Index = $i; Topic = $msg.Topic; PayloadBase64 = $b64 })
+            }
+        }
+
+        if ($RecordPath) {
+            $record = [PSCustomObject]@{
+                RecordedAt       = $captureStart.ToString('o')
+                Broker           = $Broker
+                Port             = $Port
+                DurationSeconds  = $DurationSeconds
+                MessageCount     = $recordMessages.Count
+                Messages         = @($recordMessages)
+            }
+            $dir = Split-Path -Parent $RecordPath
+            if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+            $record | ConvertTo-Json -Depth 10 -Compress:$false | Set-Content -LiteralPath $RecordPath -Encoding UTF8
+            Write-Host "Recording saved: $RecordPath ($($recordMessages.Count) messages)"
+        }
 
         if ($SelfTest) {
             $selftestCount = @($all | Where-Object { $_.Topic -eq 'PSYarbo/selftest' }).Count
@@ -96,7 +123,7 @@ function Invoke-YarboMqttSniff {
         Write-Host ""
         Write-Host "=== Sniff summary: $($all.Count) messages ==="
         if ($all.Count -gt 0) {
-            $all | Group-Object -Property Topic | Sort-Object Count -Descending | ForEach-Object {
+            @($all) | Group-Object -Property Topic | Sort-Object Count -Descending | ForEach-Object {
                 $sample = $_.Group[0]
                 Write-Host "  $($_.Count)x $($_.Name) ($($sample.PayloadBytes) bytes sample)"
             }

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -30,6 +30,11 @@
     If set, save a JSON recording of all messages (Topic, PayloadBase64, Index) to this file.
     Use with Get-YarboMqttRecordingReport to see topic coverage vs. cmdlets.
 
+\.EXAMPLE
+    Invoke-YarboMqttSniff -Broker 192.168.1.50 -DurationSeconds 30 -RecordPath ./mqtt-recording.json
+
+    Records 30 seconds of Yarbo MQTT traffic and saves a JSON recording for later analysis.
+
 .OUTPUTS
     PSCustomObject[] with Topic, PayloadBytes, At (timestamp).
 #>

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -30,7 +30,7 @@
     If set, save a JSON recording of all messages (Topic, PayloadBase64, Index) to this file.
     Use with Get-YarboMqttRecordingReport to see topic coverage vs. cmdlets.
 
-\.EXAMPLE
+.EXAMPLE
     Invoke-YarboMqttSniff -Broker 192.168.1.50 -DurationSeconds 30 -RecordPath ./mqtt-recording.json
 
     Records 30 seconds of Yarbo MQTT traffic and saves a JSON recording for later analysis.

--- a/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
+++ b/src/PSYarbo/Public/Connection/Invoke-YarboMqttSniff.ps1
@@ -102,12 +102,12 @@ function Invoke-YarboMqttSniff {
 
         if ($RecordPath) {
             $record = [PSCustomObject]@{
-                RecordedAt       = $captureStart.ToString('o')
-                Broker           = $Broker
-                Port             = $Port
-                DurationSeconds  = $DurationSeconds
-                MessageCount     = $recordMessages.Count
-                Messages         = @($recordMessages)
+                RecordedAt      = $captureStart.ToString('o')
+                Broker          = $Broker
+                Port            = $Port
+                DurationSeconds = $DurationSeconds
+                MessageCount    = $recordMessages.Count
+                Messages        = @($recordMessages)
             }
             $dir = Split-Path -Parent $RecordPath
             if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }

--- a/src/PSYarbo/Public/Control/Invoke-YarboCameraCalibration.ps1
+++ b/src/PSYarbo/Public/Control/Invoke-YarboCameraCalibration.ps1
@@ -1,0 +1,21 @@
+function Invoke-YarboCameraCalibration {
+    <#
+.SYNOPSIS
+    Runs camera calibration (camera_calibration).
+.EXAMPLE
+    Invoke-YarboCameraCalibration
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, 'Camera calibration')) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'camera_calibration' -Payload @{}
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Push-YarboSnowDir.ps1
+++ b/src/PSYarbo/Public/Control/Push-YarboSnowDir.ps1
@@ -1,0 +1,23 @@
+function Push-YarboSnowDir {
+    <#
+.SYNOPSIS
+    Pushes snow chute direction (push_snow_dir).
+.EXAMPLE
+    Push-YarboSnowDir -Direction 0
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [int]$Direction,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Push snow dir $Direction")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'push_snow_dir' -Payload @{ dir = $Direction }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Resume-YarboPlan.ps1
+++ b/src/PSYarbo/Public/Control/Resume-YarboPlan.ps1
@@ -4,7 +4,7 @@ function Resume-YarboPlan {
     Resumes a paused plan.
 
 .DESCRIPTION
-    Sends the resume command to continue a paused plan execution.
+    Sends the resume_plan command to continue a paused plan. Aligns with python-yarbo.
 
 .PARAMETER Connection
     The connection to use. Defaults to the current default.
@@ -27,7 +27,7 @@ function Resume-YarboPlan {
         $conn = Resolve-YarboConnection -Connection $Connection
         if ($PSCmdlet.ShouldProcess($conn.SerialNumber, 'Resume plan')) {
             Assert-YarboController -Connection $conn
-            return Send-MqttCommand -Connection $conn -Command 'resume' -Payload @{}
+            return Send-MqttCommand -Connection $conn -Command 'resume_plan' -Payload @{}
         }
     }
 }

--- a/src/PSYarbo/Public/Control/Send-YarboReturnToDock.ps1
+++ b/src/PSYarbo/Public/Control/Send-YarboReturnToDock.ps1
@@ -22,7 +22,7 @@ function Send-YarboReturnToDock {
     Start-YarboPlan
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
-    [Alias('Return-YarboToDock', 'Start-YarboRecharge')]
+    [Alias('Return-YarboToDock')]
     [OutputType([void])]
     param(
         [Parameter(ValueFromPipeline)]

--- a/src/PSYarbo/Public/Control/Send-YarboReturnToDock.ps1
+++ b/src/PSYarbo/Public/Control/Send-YarboReturnToDock.ps1
@@ -22,7 +22,7 @@ function Send-YarboReturnToDock {
     Start-YarboPlan
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
-    [Alias('Return-YarboToDock')]
+    [Alias('Return-YarboToDock', 'Start-YarboRecharge')]
     [OutputType([void])]
     param(
         [Parameter(ValueFromPipeline)]

--- a/src/PSYarbo/Public/Control/Set-YarboBagRecord.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboBagRecord.ps1
@@ -1,0 +1,24 @@
+function Set-YarboBagRecord {
+    <#
+.SYNOPSIS
+    Enables or disables bag record (bag_record).
+.EXAMPLE
+    Set-YarboBagRecord -Enabled $true
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [bool]$Enabled,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        $state = if ($Enabled) { 1 } else { 0 }
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set bag record $state")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'bag_record' -Payload @{ state = $state }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboBladeHeight.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboBladeHeight.ps1
@@ -1,0 +1,40 @@
+function Set-YarboBladeHeight {
+    <#
+.SYNOPSIS
+    Sets the blade cutting height (lawn mower heads).
+
+.DESCRIPTION
+    Sends set_blade_height. Aligns with python-yarbo set_blade_height.
+    Lawn Mower / Lawn Mower Pro heads.
+
+.PARAMETER Height
+    Blade height value in robot-defined units.
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Set-YarboBladeHeight -Height 3
+
+.LINK
+    Set-YarboBladeSpeed
+    about_PSYarbo_Heads
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [int]$Height,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set blade height to $Height")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_blade_height' -Payload @{ height = $Height }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboBladeSpeed.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboBladeSpeed.ps1
@@ -1,0 +1,40 @@
+function Set-YarboBladeSpeed {
+    <#
+.SYNOPSIS
+    Sets the mower blade rotation speed.
+
+.DESCRIPTION
+    Sends set_blade_speed to set the blade speed (Lawn Mower / Lawn Mower Pro heads).
+    Aligns with python-yarbo set_blade_speed. Speed units are robot-defined.
+
+.PARAMETER Speed
+    Blade speed value (robot-defined units; typically 0–max range).
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Set-YarboBladeSpeed -Speed 1500
+
+.LINK
+    Set-YarboGlobalParams
+    Get-YarboStatus
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [int]$Speed,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set blade speed to $Speed")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_blade_speed' -Payload @{ speed = $Speed }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboChargeLimit.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboChargeLimit.ps1
@@ -1,0 +1,49 @@
+function Set-YarboChargeLimit {
+    <#
+.SYNOPSIS
+    Sets the battery charge limits (min/max percentage).
+
+.DESCRIPTION
+    Sends set_charge_limit so the robot returns to dock when battery falls to
+    MinPercent and stops charging at MaxPercent. Aligns with python-yarbo
+    set_charge_limit(min_pct, max_pct).
+
+.PARAMETER MinPercent
+    Minimum charge percentage before the robot returns to dock (e.g. 20).
+
+.PARAMETER MaxPercent
+    Maximum charge percentage at which charging stops (e.g. 100).
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Set-YarboChargeLimit -MinPercent 20 -MaxPercent 100
+
+.LINK
+    Get-YarboBattery
+    Send-YarboReturnToDock
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateRange(0, 100)]
+        [int]$MinPercent,
+
+        [Parameter(Mandatory, Position = 1)]
+        [ValidateRange(0, 100)]
+        [int]$MaxPercent,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set charge limit min=$MinPercent% max=$MaxPercent%")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_charge_limit' -Payload @{ min = $MinPercent; max = $MaxPercent }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboChildLock.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboChildLock.ps1
@@ -1,0 +1,24 @@
+function Set-YarboChildLock {
+    <#
+.SYNOPSIS
+    Sets child lock state (child_lock).
+.EXAMPLE
+    Set-YarboChildLock -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set ChildLock $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'child_lock' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboChuteSteeringWork.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboChuteSteeringWork.ps1
@@ -1,0 +1,39 @@
+function Set-YarboChuteSteeringWork {
+    <#
+.SYNOPSIS
+    Sets the chute steering state during work (snow blower head).
+
+.DESCRIPTION
+    Sends set_chute_steering_work. Aligns with python-yarbo set_chute_steering_work.
+
+.PARAMETER State
+    Chute steering state (robot-defined integer).
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Set-YarboChuteSteeringWork -State 1
+
+.LINK
+    Set-YarboChute
+    about_PSYarbo_Heads
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [int]$State,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set chute steering work state $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_chute_steering_work' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboEdgeBlowing.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboEdgeBlowing.ps1
@@ -1,0 +1,24 @@
+function Set-YarboEdgeBlowing {
+    <#
+.SYNOPSIS
+    Sets edge blowing state (edge_blowing).
+.EXAMPLE
+    Set-YarboEdgeBlowing -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set edge blowing $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'edge_blowing' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboElecFence.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboElecFence.ps1
@@ -1,0 +1,24 @@
+function Set-YarboElecFence {
+    <#
+.SYNOPSIS
+    Enables or disables electric fence (enable_elec_fence).
+.EXAMPLE
+    Set-YarboElecFence -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set ElecFence $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'enable_elec_fence' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboFollowState.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboFollowState.ps1
@@ -1,0 +1,24 @@
+function Set-YarboFollowState {
+    <#
+.SYNOPSIS
+    Sets follow state (set_follow_state).
+.EXAMPLE
+    Set-YarboFollowState -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set follow state $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_follow_state' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboGeoFence.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboGeoFence.ps1
@@ -1,0 +1,24 @@
+function Set-YarboGeoFence {
+    <#
+.SYNOPSIS
+    Enables or disables geo fence (enable_geo_fence).
+.EXAMPLE
+    Set-YarboGeoFence -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set GeoFence $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'enable_geo_fence' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboGlobalParams.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboGlobalParams.ps1
@@ -52,13 +52,6 @@ function Set-YarboGlobalParams {
                 foreach ($prop in $Parameters.RawData.PSObject.Properties) {
                     $ht[$prop.Name] = $prop.Value
                 }
-                
-                # Sync typed properties back to payload to prevent silent data loss
-                if ($null -ne $Parameters.MowSpeed) { $ht['mow_speed'] = $Parameters.MowSpeed }
-                if ($null -ne $Parameters.CuttingHeight) { $ht['cutting_height'] = $Parameters.CuttingHeight }
-                if ($null -ne $Parameters.RainDelay) { $ht['rain_delay'] = $Parameters.RainDelay }
-                if ($null -ne $Parameters.ObstacleSensitivity) { $ht['obstacle_sensitivity'] = $Parameters.ObstacleSensitivity }
-                
                 $ht
             } else {
                 throw "YarboGlobalParams object has no RawData. Use Get-YarboGlobalParams to retrieve current parameters first."

--- a/src/PSYarbo/Public/Control/Set-YarboGlobalParams.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboGlobalParams.ps1
@@ -12,15 +12,16 @@ function Set-YarboGlobalParams {
     behaviour. Use -WhatIf or -Confirm to preview changes before applying.
 
 .PARAMETER Parameters
-    Hashtable of parameter key-value pairs to save. Obtain current values via
-    Get-YarboGlobalParams and modify as needed.
+    Hashtable of parameter key-value pairs to save, or a YarboGlobalParams object
+    from Get-YarboGlobalParams. When passing a YarboGlobalParams object, the RawData
+    property is used to send all parameters back to the device.
 
 .PARAMETER Connection
     The connection to use. Defaults to the current default.
 
 .EXAMPLE
     $params = Get-YarboGlobalParams
-    $params.mow_speed = 0.5
+    $params.RawData.mow_speed = 0.5
     Set-YarboGlobalParams -Parameters $params
 
 .EXAMPLE
@@ -36,7 +37,7 @@ function Set-YarboGlobalParams {
     [OutputType([YarboCommandResult])]
     param(
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)]
-        [hashtable]$Parameters,
+        [object]$Parameters,
 
         [Parameter()]
         [YarboConnection]$Connection
@@ -45,10 +46,26 @@ function Set-YarboGlobalParams {
     process {
         $conn = Resolve-YarboConnection -Connection $Connection
 
-        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Save global params: $($Parameters.Keys -join ', ')")) {
+        $payload = if ($Parameters -is [YarboGlobalParams]) {
+            if ($Parameters.RawData) {
+                $ht = @{}
+                foreach ($prop in $Parameters.RawData.PSObject.Properties) {
+                    $ht[$prop.Name] = $prop.Value
+                }
+                $ht
+            } else {
+                throw "YarboGlobalParams object has no RawData. Use Get-YarboGlobalParams to retrieve current parameters first."
+            }
+        } elseif ($Parameters -is [hashtable]) {
+            $Parameters
+        } else {
+            throw "Parameters must be a hashtable or YarboGlobalParams object."
+        }
+
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Save global params: $($payload.Keys -join ', ')")) {
             Assert-YarboController -Connection $conn
             Write-Verbose (Protect-YarboLogMessage "[Set-YarboGlobalParams] Routing via local MQTT → cmd_save_para")
-            $result = Send-MqttCommand -Connection $conn -Command 'cmd_save_para' -Payload $Parameters
+            $result = Send-MqttCommand -Connection $conn -Command 'cmd_save_para' -Payload $payload
 
             if ($result -and -not $result.Success) {
                 $PSCmdlet.WriteError((New-YarboError `

--- a/src/PSYarbo/Public/Control/Set-YarboGlobalParams.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboGlobalParams.ps1
@@ -52,6 +52,13 @@ function Set-YarboGlobalParams {
                 foreach ($prop in $Parameters.RawData.PSObject.Properties) {
                     $ht[$prop.Name] = $prop.Value
                 }
+                
+                # Sync typed properties back to payload to prevent silent data loss
+                if ($null -ne $Parameters.MowSpeed) { $ht['mow_speed'] = $Parameters.MowSpeed }
+                if ($null -ne $Parameters.CuttingHeight) { $ht['cutting_height'] = $Parameters.CuttingHeight }
+                if ($null -ne $Parameters.RainDelay) { $ht['rain_delay'] = $Parameters.RainDelay }
+                if ($null -ne $Parameters.ObstacleSensitivity) { $ht['obstacle_sensitivity'] = $Parameters.ObstacleSensitivity }
+                
                 $ht
             } else {
                 throw "YarboGlobalParams object has no RawData. Use Get-YarboGlobalParams to retrieve current parameters first."

--- a/src/PSYarbo/Public/Control/Set-YarboGreengrassUpdateSwitch.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboGreengrassUpdateSwitch.ps1
@@ -5,4 +5,21 @@ function Set-YarboGreengrassUpdateSwitch {
 .EXAMPLE
     Set-YarboGreengrassUpdateSwitch -State 1
 #>
-    [CmdletBinding(SupportsShouldProcess)] [OutputType([YarboCommandResult])] param([Parameter(Mandatory,Position=0)][ValidateSet(0,1)][int]$State,[Parameter(ValueFromPipeline)][YarboConnection]$Connection) process { $conn = Resolve-YarboConnection -Connection $Connection; if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set Greengrass update switch $State")) { Assert-YarboController -Connection $conn; $cmd = 'set_greengrass_auto_update_switch'; return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{ state = $State } } } }
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set Greengrass update switch $State")) {
+            Assert-YarboController -Connection $conn
+            $cmd = 'set_greengrass_auto_update_switch'
+            return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboGreengrassUpdateSwitch.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboGreengrassUpdateSwitch.ps1
@@ -1,0 +1,8 @@
+function Set-YarboGreengrassUpdateSwitch {
+    <#
+.SYNOPSIS
+    Sets Greengrass auto-update switch (set_greengrass_auto_update_switch).
+.EXAMPLE
+    Set-YarboGreengrassUpdateSwitch -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)] [OutputType([YarboCommandResult])] param([Parameter(Mandatory,Position=0)][ValidateSet(0,1)][int]$State,[Parameter(ValueFromPipeline)][YarboConnection]$Connection) process { $conn = Resolve-YarboConnection -Connection $Connection; if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set Greengrass update switch $State")) { Assert-YarboController -Connection $conn; $cmd = 'set_greengrass_auto_update_switch'; return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{ state = $State } } } }

--- a/src/PSYarbo/Public/Control/Set-YarboHeatingFilm.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboHeatingFilm.ps1
@@ -1,0 +1,24 @@
+function Set-YarboHeatingFilm {
+    <#
+.SYNOPSIS
+    Controls heating film (heating_film_ctrl).
+.EXAMPLE
+    Set-YarboHeatingFilm -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set heating film $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'heating_film_ctrl' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboIpcameraOtaSwitch.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboIpcameraOtaSwitch.ps1
@@ -5,4 +5,21 @@ function Set-YarboIpcameraOtaSwitch {
 .EXAMPLE
     Set-YarboIpcameraOtaSwitch -State 1
 #>
-    [CmdletBinding(SupportsShouldProcess)] [OutputType([YarboCommandResult])] param([Parameter(Mandatory,Position=0)][ValidateSet(0,1)][int]$State,[Parameter(ValueFromPipeline)][YarboConnection]$Connection) process { $conn = Resolve-YarboConnection -Connection $Connection; if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set IP camera OTA switch $State")) { Assert-YarboController -Connection $conn; $cmd = 'set_ipcamera_ota_switch'; return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{ state = $State } } } }
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set IP camera OTA switch $State")) {
+            Assert-YarboController -Connection $conn
+            $cmd = 'set_ipcamera_ota_switch'
+            return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboIpcameraOtaSwitch.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboIpcameraOtaSwitch.ps1
@@ -1,0 +1,8 @@
+function Set-YarboIpcameraOtaSwitch {
+    <#
+.SYNOPSIS
+    Sets IP camera OTA switch (set_ipcamera_ota_switch).
+.EXAMPLE
+    Set-YarboIpcameraOtaSwitch -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)] [OutputType([YarboCommandResult])] param([Parameter(Mandatory,Position=0)][ValidateSet(0,1)][int]$State,[Parameter(ValueFromPipeline)][YarboConnection]$Connection) process { $conn = Resolve-YarboConnection -Connection $Connection; if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set IP camera OTA switch $State")) { Assert-YarboController -Connection $conn; $cmd = 'set_ipcamera_ota_switch'; return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{ state = $State } } } }

--- a/src/PSYarbo/Public/Control/Set-YarboModuleLock.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboModuleLock.ps1
@@ -1,0 +1,24 @@
+function Set-YarboModuleLock {
+    <#
+.SYNOPSIS
+    Controls module lock (module_lock_ctl).
+.EXAMPLE
+    Set-YarboModuleLock -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set module lock $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'module_lock_ctl' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboMotorProtect.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboMotorProtect.ps1
@@ -1,0 +1,24 @@
+function Set-YarboMotorProtect {
+    <#
+.SYNOPSIS
+    Sets motor protect state (cmd_motor_protect).
+.EXAMPLE
+    Set-YarboMotorProtect -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set motor protect $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'cmd_motor_protect' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboNgzEdge.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboNgzEdge.ps1
@@ -1,0 +1,24 @@
+function Set-YarboNgzEdge {
+    <#
+.SYNOPSIS
+    Sets NGZ edge state (ngz_edge).
+.EXAMPLE
+    Set-YarboNgzEdge -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set NgzEdge $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'ngz_edge' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboRollerSpeed.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboRollerSpeed.ps1
@@ -1,0 +1,40 @@
+function Set-YarboRollerSpeed {
+    <#
+.SYNOPSIS
+    Sets the roller/blower speed (leaf blower head).
+
+.DESCRIPTION
+    Sends set_roller_speed. Aligns with python-yarbo set_roller_speed.
+    Distinct from Set-YarboRoller which uses cmd_roller (manual drive).
+
+.PARAMETER Speed
+    Speed value in robot-defined units.
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Set-YarboRollerSpeed -Speed 1000
+
+.LINK
+    Set-YarboRoller
+    about_PSYarbo_Heads
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [int]$Speed,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set roller speed to $Speed")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_roller_speed' -Payload @{ speed = $Speed }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboSmartBlowing.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboSmartBlowing.ps1
@@ -1,0 +1,24 @@
+function Set-YarboSmartBlowing {
+    <#
+.SYNOPSIS
+    Sets smart blowing state (smart_blowing).
+.EXAMPLE
+    Set-YarboSmartBlowing -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set smart blowing $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'smart_blowing' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboSmartVision.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboSmartVision.ps1
@@ -1,0 +1,24 @@
+function Set-YarboSmartVision {
+    <#
+.SYNOPSIS
+    Sets smart vision state (smart_vision_control).
+.EXAMPLE
+    Set-YarboSmartVision -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set smart vision $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'smart_vision_control' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboTrimmer.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboTrimmer.ps1
@@ -1,0 +1,24 @@
+function Set-YarboTrimmer {
+    <#
+.SYNOPSIS
+    Sets trimmer state (cmd_trimmer).
+.EXAMPLE
+    Set-YarboTrimmer -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set trimmer $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'cmd_trimmer' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboTurnType.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboTurnType.ps1
@@ -1,0 +1,23 @@
+function Set-YarboTurnType {
+    <#
+.SYNOPSIS
+    Sets the turn type (set_turn_type).
+.EXAMPLE
+    Set-YarboTurnType -TurnType 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [int]$TurnType,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set turn type to $TurnType")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'set_turn_type' -Payload @{ turnType = $TurnType }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Set-YarboVideoRecord.ps1
+++ b/src/PSYarbo/Public/Control/Set-YarboVideoRecord.ps1
@@ -1,0 +1,24 @@
+function Set-YarboVideoRecord {
+    <#
+.SYNOPSIS
+    Enables or disables video recording (enable_video_record).
+.EXAMPLE
+    Set-YarboVideoRecord -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Set video record $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'enable_video_record' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Start-YarboDrawCmd.ps1
+++ b/src/PSYarbo/Public/Control/Start-YarboDrawCmd.ps1
@@ -1,0 +1,24 @@
+function Start-YarboDrawCmd {
+    <#
+.SYNOPSIS
+    Starts draw command (start_draw_cmd).
+.EXAMPLE
+    Start-YarboDrawCmd -State 1
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet(0, 1)]
+        [int]$State,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Start draw cmd $State")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'start_draw_cmd' -Payload @{ state = $State }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Control/Start-YarboPlan.ps1
+++ b/src/PSYarbo/Public/Control/Start-YarboPlan.ps1
@@ -12,6 +12,9 @@ function Start-YarboPlan {
 .PARAMETER Name
     Plan name — resolved to PlanId via Get-YarboPlan.
 
+.PARAMETER Percent
+    Optional start percentage (0–100). When set, the plan may start from that progress point (firmware-dependent). Aligns with python-yarbo start_plan(percent=).
+
 .PARAMETER Connection
     The connection to use. Defaults to the current default.
 
@@ -36,7 +39,12 @@ function Start-YarboPlan {
         [int]$PlanId,
 
         [Parameter(Mandatory, ParameterSetName = 'ByName')]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'ById')]
+        [Parameter(ParameterSetName = 'ByName')]
+        [ValidateRange(0, 100)]
+        [int]$Percent = -1
     )
 
     process {
@@ -55,8 +63,12 @@ function Start-YarboPlan {
 
         if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Start plan $resolvedId")) {
             Assert-YarboController -Connection $conn
+            $payload = @{ planId = [int]$resolvedId }
+            if ($Percent -ge 0) {
+                $payload['percent'] = [int]$Percent
+            }
             Write-Verbose (Protect-YarboLogMessage "[Start-YarboPlan] Routing via local MQTT → start_plan (planId=$resolvedId)")
-            $result = Send-MqttCommand -Connection $conn -Command 'start_plan' -Payload @{ planId = [int]$resolvedId }
+            $result = Send-MqttCommand -Connection $conn -Command 'start_plan' -Payload $payload
             if ($result -and -not $result.Success) {
                 $PSCmdlet.WriteError((New-YarboError -Message "start_plan failed: $($result.Message)" -ErrorId 'PSYarbo.CommandFailed.StartPlan' -Category 'InvalidResult' -TargetObject $result))
             }

--- a/src/PSYarbo/Public/Control/Stop-YarboPlan.ps1
+++ b/src/PSYarbo/Public/Control/Stop-YarboPlan.ps1
@@ -4,7 +4,7 @@ function Stop-YarboPlan {
     Stops the currently running plan.
 
 .DESCRIPTION
-    Sends the stop command to halt plan execution.
+    Sends the stop_plan command to halt plan execution. Aligns with python-yarbo.
 
 .PARAMETER Connection
     The connection to use. Defaults to the current default.
@@ -27,7 +27,7 @@ function Stop-YarboPlan {
         $conn = Resolve-YarboConnection -Connection $Connection
         if ($PSCmdlet.ShouldProcess($conn.SerialNumber, 'Stop plan')) {
             Assert-YarboController -Connection $conn
-            return Send-MqttCommand -Connection $conn -Command 'stop' -Payload @{}
+            return Send-MqttCommand -Connection $conn -Command 'stop_plan' -Payload @{}
         }
     }
 }

--- a/src/PSYarbo/Public/Control/Update-YarboFirmware.ps1
+++ b/src/PSYarbo/Public/Control/Update-YarboFirmware.ps1
@@ -1,0 +1,48 @@
+function Update-YarboFirmware {
+    <#
+.SYNOPSIS
+    Triggers or schedules a firmware update.
+
+.DESCRIPTION
+    Sends firmware_update_now, firmware_update_tonight, or firmware_update_later.
+    Aligns with python-yarbo. -When Now is destructive and requires -Confirm.
+
+.PARAMETER When
+    Now = immediate (requires -Confirm), Tonight = schedule for tonight, Later = defer.
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Update-YarboFirmware -When Tonight
+
+.EXAMPLE
+    Update-YarboFirmware -When Now -Confirm
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateSet('Now', 'Tonight', 'Later')]
+        [string]$When,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        $cmd = switch ($When) {
+            'Now'     { 'firmware_update_now' }
+            'Tonight' { 'firmware_update_tonight' }
+            'Later'   { 'firmware_update_later' }
+        }
+        $action = "Firmware update $When"
+        if ($When -eq 'Now') {
+            $action = 'Firmware update NOW (destructive)'
+        }
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, $action)) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command $cmd -Payload @{}
+        }
+    }
+}

--- a/src/PSYarbo/Public/Plans/Clear-YarboMap.ps1
+++ b/src/PSYarbo/Public/Plans/Clear-YarboMap.ps1
@@ -1,0 +1,25 @@
+function Clear-YarboMap {
+    <#
+.SYNOPSIS
+    Erases the robot's stored map (destructive).
+
+.DESCRIPTION
+    Sends erase_map. Aligns with python-yarbo erase_map. Requires -Confirm.
+
+.EXAMPLE
+    Clear-YarboMap -Confirm
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, 'Erase map (destructive)')) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'erase_map' -Payload @{}
+        }
+    }
+}

--- a/src/PSYarbo/Public/Plans/Restore-YarboMap.ps1
+++ b/src/PSYarbo/Public/Plans/Restore-YarboMap.ps1
@@ -1,0 +1,30 @@
+function Restore-YarboMap {
+    <#
+.SYNOPSIS
+    Restores a map from backup by ID (destructive).
+
+.DESCRIPTION
+    Sends map_recovery. Aligns with python-yarbo map_recovery. Requires -Confirm.
+
+.PARAMETER MapId
+    ID of the map backup to restore (from Get-YarboMapBackup).
+
+.EXAMPLE
+    Restore-YarboMap -MapId 'abc123' -Confirm
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$MapId,
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, "Restore map $MapId (destructive)")) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'map_recovery' -Payload @{ mapId = $MapId }
+        }
+    }
+}

--- a/src/PSYarbo/Public/Plans/Save-YarboCurrentMap.ps1
+++ b/src/PSYarbo/Public/Plans/Save-YarboCurrentMap.ps1
@@ -1,0 +1,26 @@
+function Save-YarboCurrentMap {
+    <#
+.SYNOPSIS
+    Saves the robot's current map state.
+
+.DESCRIPTION
+    Sends save_current_map. Aligns with python-yarbo save_current_map.
+    Distinct from Save-YarboMapBackup which triggers a full backup.
+
+.EXAMPLE
+    Save-YarboCurrentMap
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([YarboCommandResult])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        if ($PSCmdlet.ShouldProcess($conn.SerialNumber, 'Save current map')) {
+            Assert-YarboController -Connection $conn
+            return Send-MqttCommand -Connection $conn -Command 'save_current_map' -Payload @{}
+        }
+    }
+}

--- a/src/PSYarbo/Public/Status/Get-YarboCameraStatus.ps1
+++ b/src/PSYarbo/Public/Status/Get-YarboCameraStatus.ps1
@@ -1,0 +1,20 @@
+function Get-YarboCameraStatus {
+    <#
+.SYNOPSIS
+    Gets the camera status (check_camera_status).
+.EXAMPLE
+    Get-YarboCameraStatus
+#>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        $result = Send-MqttCommand -Connection $conn -Command 'check_camera_status' -Payload @{}
+        if ($null -eq $result -or -not $result.Success) { return }
+        return $result.Data
+    }
+}

--- a/src/PSYarbo/Public/Status/Get-YarboGlobalParams.ps1
+++ b/src/PSYarbo/Public/Status/Get-YarboGlobalParams.ps1
@@ -59,11 +59,13 @@ function Get-YarboGlobalParams {
         $p = [YarboGlobalParams]::new()
         $d = $result.Data
         $p.RawData = $d
-        if ($d.PSObject.Properties['mow_speed']) { $p.MowSpeed = [double]$d.mow_speed }
-        if ($d.PSObject.Properties['cutting_height']) { $p.CuttingHeight = [int]$d.cutting_height }
-        if ($d.PSObject.Properties['rain_delay']) { $p.RainDelay = [int]$d.rain_delay }
-        if ($d.PSObject.Properties['obstacle_sensitivity']) { $p.ObstacleSensitivity = [int]$d.obstacle_sensitivity }
-        if ($d.PSObject.Properties['timestamp']) { $p.Timestamp = [double]$d.timestamp }
+        if ($null -ne $d) {
+            if ($d.PSObject.Properties['mow_speed']) { $p.MowSpeed = [double]$d.mow_speed }
+            if ($d.PSObject.Properties['cutting_height']) { $p.CuttingHeight = [int]$d.cutting_height }
+            if ($d.PSObject.Properties['rain_delay']) { $p.RainDelay = [int]$d.rain_delay }
+            if ($d.PSObject.Properties['obstacle_sensitivity']) { $p.ObstacleSensitivity = [int]$d.obstacle_sensitivity }
+            if ($d.PSObject.Properties['timestamp']) { $p.Timestamp = [double]$d.timestamp }
+        }
         return $p
     }
 }

--- a/src/PSYarbo/Public/Status/Get-YarboGlobalParams.ps1
+++ b/src/PSYarbo/Public/Status/Get-YarboGlobalParams.ps1
@@ -25,7 +25,7 @@ function Get-YarboGlobalParams {
         'PSUseSingularNouns', '',
         Justification = '"Params" is an established abbreviation for Parameters; renaming would break the documented API')]
     [CmdletBinding()]
-    [OutputType([PSCustomObject])]
+    [OutputType([YarboGlobalParams])]
     param(
         [Parameter(ValueFromPipeline)]
         [YarboConnection]$Connection
@@ -56,6 +56,14 @@ function Get-YarboGlobalParams {
             return
         }
 
-        return $result.Data
+        $p = [YarboGlobalParams]::new()
+        $d = $result.Data
+        $p.RawData = $d
+        if ($d.PSObject.Properties['mow_speed']) { $p.MowSpeed = [double]$d.mow_speed }
+        if ($d.PSObject.Properties['cutting_height']) { $p.CuttingHeight = [int]$d.cutting_height }
+        if ($d.PSObject.Properties['rain_delay']) { $p.RainDelay = [int]$d.rain_delay }
+        if ($d.PSObject.Properties['obstacle_sensitivity']) { $p.ObstacleSensitivity = [int]$d.obstacle_sensitivity }
+        if ($d.PSObject.Properties['timestamp']) { $p.Timestamp = [double]$d.timestamp }
+        return $p
     }
 }

--- a/src/PSYarbo/Public/Status/Get-YarboSavedWifiList.ps1
+++ b/src/PSYarbo/Public/Status/Get-YarboSavedWifiList.ps1
@@ -1,0 +1,46 @@
+function Get-YarboSavedWifiList {
+    <#
+.SYNOPSIS
+    Retrieves the list of saved Wi-Fi networks on the robot.
+
+.DESCRIPTION
+    Sends get_saved_wifi_list and returns the data feedback response containing
+    Wi-Fi networks previously saved on the robot. Aligns with python-yarbo
+    get_saved_wifi_list.
+
+.PARAMETER Connection
+    The connection to use. Defaults to the current default.
+
+.EXAMPLE
+    Get-YarboSavedWifiList
+
+.EXAMPLE
+    Get-YarboSavedWifiList | ConvertTo-Json
+
+.LINK
+    Get-YarboWifiList
+    Get-YarboConnectedWifi
+    Start-YarboHotspot
+#>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection
+    )
+
+    process {
+        $conn = Resolve-YarboConnection -Connection $Connection
+        Write-Verbose (Protect-YarboLogMessage "[Get-YarboSavedWifiList] Routing via local MQTT → get_saved_wifi_list")
+        $result = Send-MqttCommand -Connection $conn -Command 'get_saved_wifi_list' -Payload @{}
+
+        if ($null -eq $result -or -not $result.Success) {
+            if ($result) {
+                $PSCmdlet.WriteError((New-YarboError -Message "get_saved_wifi_list failed: $($result.Message)" -ErrorId 'PSYarbo.CommandFailed.GetSavedWifiList' -Category 'InvalidResult'))
+            }
+            return
+        }
+
+        return $result.Data
+    }
+}

--- a/src/PSYarbo/Public/Status/Get-YarboStatus.ps1
+++ b/src/PSYarbo/Public/Status/Get-YarboStatus.ps1
@@ -13,7 +13,7 @@ function Get-YarboStatus {
     Get-YarboStatus
 
 .EXAMPLE
-    Connect-Yarbo -Broker 192.168.1.24 -SerialNumber 24400102L8HO5227 | Get-YarboStatus
+    Connect-Yarbo -Broker <rover-ip> -SerialNumber <serial-number> | Get-YarboStatus
 
 .LINK
     Get-YarboRobot

--- a/src/PSYarbo/Public/Telemetry/Watch-YarboTelemetry.ps1
+++ b/src/PSYarbo/Public/Telemetry/Watch-YarboTelemetry.ps1
@@ -30,6 +30,10 @@ function Watch-YarboTelemetry {
 .PARAMETER IncludePlanFeedback
     Also emit plan_feedback and recharge_feedback messages in the stream as raw PSCustomObject.
 
+.PARAMETER Raw
+    Emit raw PSCustomObject (decoded DeviceMSG) instead of [YarboTelemetry] for DeviceMSG events.
+    Heartbeat and feedback events are always raw when included.
+
 .PARAMETER Connection
     The connection to use. Defaults to the current default.
 
@@ -75,7 +79,10 @@ function Watch-YarboTelemetry {
         [switch]$IncludeHeartbeat,
 
         [Parameter()]
-        [switch]$IncludePlanFeedback
+        [switch]$IncludePlanFeedback,
+
+        [Parameter()]
+        [switch]$Raw
     )
 
     process {
@@ -120,17 +127,21 @@ function Watch-YarboTelemetry {
 
                 # Emit in requested format
                 if ($event.MessageType -eq 'DeviceMSG') {
-                    switch ($OutputFormat) {
-                        'Object' {
-                            $telemetry = ConvertTo-YarboTelemetry -DeviceMsg $event.Data -SerialNumber $conn.SerialNumber
-                            $PSCmdlet.WriteObject($telemetry)
-                        }
-                        'Json' {
-                            $PSCmdlet.WriteObject(($event.Data | ConvertTo-Json -Compress -Depth 10))
-                        }
-                        'Summary' {
-                            $t = ConvertTo-YarboTelemetry -DeviceMsg $event.Data -SerialNumber $conn.SerialNumber
-                            $PSCmdlet.WriteObject("$($t.Timestamp.ToString('HH:mm:ss')) | Bat:$($t.BatteryCapacity)% | State:$($t.WorkingState) | Pos:$([math]::Round($t.X,2)),$([math]::Round($t.Y,2))")
+                    if ($Raw) {
+                        $PSCmdlet.WriteObject($event.Data)
+                    } else {
+                        switch ($OutputFormat) {
+                            'Object' {
+                                $telemetry = ConvertTo-YarboTelemetry -DeviceMsg $event.Data -SerialNumber $conn.SerialNumber
+                                $PSCmdlet.WriteObject($telemetry)
+                            }
+                            'Json' {
+                                $PSCmdlet.WriteObject(($event.Data | ConvertTo-Json -Compress -Depth 10))
+                            }
+                            'Summary' {
+                                $t = ConvertTo-YarboTelemetry -DeviceMsg $event.Data -SerialNumber $conn.SerialNumber
+                                $PSCmdlet.WriteObject("$($t.Timestamp.ToString('HH:mm:ss')) | Bat:$($t.BatteryCapacity)% | State:$($t.WorkingState) | Pos:$([math]::Round($t.X,2)),$([math]::Round($t.Y,2))")
+                            }
                         }
                     }
                 } else {

--- a/src/PSYarbo/Public/Utility/Export-YarboSupportBundle.ps1
+++ b/src/PSYarbo/Public/Utility/Export-YarboSupportBundle.ps1
@@ -126,17 +126,18 @@ function Export-YarboSupportBundle {
                         Timestamp = $_.Timestamp.ToString('o')
                         Command   = $_.Command
                         Direction = $_.Direction
-                        Topic     = $_.Topic
                     }
+                    if ($_.PSObject.Properties['Topic']) { $entry['Topic'] = $_.Topic }
                     if ($_.PSObject.Properties['State']) { $entry['State'] = $_.State }
                     if ($_.PSObject.Properties['Message']) { $entry['Message'] = if ($_.Message) { Protect-YarboLogMessage $_.Message } else { $null } }
                     $entry
                 })
             TelemetryLog = @($telArr | ForEach-Object {
                     [ordered]@{
-                        At     = $_.At.ToString('o')
-                        Topic  = $_.Topic
-                        Source = $_.Source
+                        Timestamp   = $_.Timestamp.ToString('o')
+                        MessageType = $_.MessageType
+                        Direction   = $_.Direction
+                        Topic       = $_.Topic
                     }
                 })
         }

--- a/src/PSYarbo/Public/Utility/Export-YarboSupportBundle.ps1
+++ b/src/PSYarbo/Public/Utility/Export-YarboSupportBundle.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    Exports a redacted MQTT/connection bundle for support (e.g. GlitchTip or maintainers).
+
+.DESCRIPTION
+    Produces a JSON file containing MQTT and connection metadata plus redacted message summaries.
+    Use this when reporting issues or when asked to provide a "full MQTT dump" for troubleshooting
+    firmware versions, heads/attachments, or unsupported configurations.
+    Sensitive data (tokens, credentials) is redacted. You can upload the output file to your
+    issue tracker or GlitchTip.
+
+.PARAMETER Path
+    Output file path for the support bundle (JSON). Created if the directory does not exist.
+
+.PARAMETER RecordingPath
+    Optional. Path to a recording from Invoke-YarboMqttSniff -RecordPath. If provided, the bundle
+    includes topic list, message counts, and decoded payload keys (values redacted) from that recording.
+
+.PARAMETER Connection
+    Optional. A YarboConnection. If provided, the bundle includes the last N entries from
+    CommandLog and TelemetryLog (no raw payloads are stored there; safe to export).
+
+.PARAMETER CommandLogEntries
+    When -Connection is used, how many recent CommandLog entries to include. Default 100.
+
+.PARAMETER TelemetryLogEntries
+    When -Connection is used, how many recent TelemetryLog entries to include. Default 50.
+
+.EXAMPLE
+    Export-YarboSupportBundle -Path ./support-bundle.json -RecordingPath ./mqtt-recording.json
+
+.EXAMPLE
+    $conn = Connect-Yarbo -Broker 192.0.2.1 -SerialNumber YB123
+    Get-YarboStatus -Connection $conn
+    Export-YarboSupportBundle -Path ./support-bundle.json -Connection $conn
+
+.LINK
+    Invoke-YarboMqttSniff
+    Get-YarboMqttRecordingReport
+    https://github.com/markus-lassfolk/python-yarbo/issues/59
+#>
+function Export-YarboSupportBundle {
+    [CmdletBinding()]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter()]
+        [string]$RecordingPath,
+
+        [Parameter(ValueFromPipeline)]
+        [YarboConnection]$Connection,
+
+        [Parameter()]
+        [ValidateRange(1, 1000)]
+        [int]$CommandLogEntries = 100,
+
+        [Parameter()]
+        [ValidateRange(1, 500)]
+        [int]$TelemetryLogEntries = 50
+    )
+
+    $bundle = [ordered]@{
+        ExportDate    = [datetime]::UtcNow.ToString('o')
+        Module        = 'PSYarbo'
+        ModuleVersion = $script:ModuleVersion
+        Source        = [System.Collections.Generic.List[string]]::new()
+        Recording     = $null
+        ConnectionLog = $null
+    }
+
+    if ($RecordingPath) {
+        if (-not (Test-Path -LiteralPath $RecordingPath)) {
+            $PSCmdlet.WriteError([System.Management.Automation.ErrorRecord]::new(
+                    [System.IO.FileNotFoundException]::new("Recording not found.", $RecordingPath),
+                    'PSYarbo.RecordingNotFound',
+                    [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                    $RecordingPath
+                ))
+        } else {
+            $bundle.Source.Add('Recording')
+            $raw = Get-Content -LiteralPath $RecordingPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $messages = @($raw.Messages)
+            $byTopic = @{}
+            $decodedSamples = @{}
+            foreach ($m in $messages) {
+                $t = $m.Topic
+                if (-not $byTopic[$t]) { $byTopic[$t] = 0 }
+                $byTopic[$t]++
+                if (-not $decodedSamples[$t] -and $m.PayloadBase64) {
+                    try {
+                        $bytes = [Convert]::FromBase64String($m.PayloadBase64)
+                        $decoded = ConvertFrom-ZlibPayload -Data $bytes
+                        if ($decoded -is [PSCustomObject]) {
+                            $keys = ($decoded.PSObject.Properties | ForEach-Object { $_.Name }) -join ', '
+                            $decodedSamples[$t] = Protect-YarboLogMessage $keys
+                        }
+                    } catch { $decodedSamples[$t] = '(decode failed)' }
+                }
+            }
+            $bundle.Recording = [ordered]@{
+                RecordedAt       = $raw.RecordedAt
+                Broker           = $raw.Broker
+                Port             = $raw.Port
+                DurationSeconds  = $raw.DurationSeconds
+                MessageCount     = $messages.Count
+                Topics           = [ordered]@{}
+                DecodedKeysSample = [ordered]@{}
+            }
+            foreach ($t in ($byTopic.Keys | Sort-Object)) { $bundle.Recording.Topics[$t] = $byTopic[$t] }
+            foreach ($t in ($decodedSamples.Keys | Sort-Object)) { $bundle.Recording.DecodedKeysSample[$t] = $decodedSamples[$t] }
+        }
+    }
+
+    if ($Connection) {
+        $bundle.Source.Add('Connection')
+        $cmdArr = $Connection.CommandLog.ToArray() | Select-Object -Last $CommandLogEntries
+        $telArr = $Connection.TelemetryLog.ToArray() | Select-Object -Last $TelemetryLogEntries
+        $bundle.ConnectionLog = [ordered]@{
+            Broker        = $Connection.Broker
+            Port          = $Connection.Port
+            SerialNumber  = $Connection.SerialNumber
+            CommandLog    = @($cmdArr | ForEach-Object {
+                    $entry = [ordered]@{
+                        Timestamp = $_.Timestamp.ToString('o')
+                        Command   = $_.Command
+                        Direction = $_.Direction
+                        Topic     = $_.Topic
+                    }
+                    if ($_.PSObject.Properties['State']) { $entry['State'] = $_.State }
+                    if ($_.PSObject.Properties['Message']) { $entry['Message'] = if ($_.Message) { Protect-YarboLogMessage $_.Message } else { $null } }
+                    $entry
+                })
+            TelemetryLog = @($telArr | ForEach-Object {
+                    [ordered]@{
+                        At     = $_.At.ToString('o')
+                        Topic  = $_.Topic
+                        Source = $_.Source
+                    }
+                })
+        }
+    }
+
+    if ($bundle.Source.Count -eq 0) {
+        $PSCmdlet.ThrowTerminatingError([System.Management.Automation.ErrorRecord]::new(
+                [System.ArgumentException]::new('Specify at least one of -RecordingPath or -Connection.'),
+                'PSYarbo.SupportBundleNoSource',
+                [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                $null
+            ))
+    }
+
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $bundle | ConvertTo-Json -Depth 10 -Compress:$false | Set-Content -LiteralPath $Path -Encoding UTF8
+    Write-Verbose "Support bundle written to $Path (sources: $($bundle.Source -join ', ')). You can upload this to GlitchTip or attach to an issue."
+    Get-Item -LiteralPath $Path
+}

--- a/src/PSYarbo/Public/Utility/Export-YarboSupportBundle.ps1
+++ b/src/PSYarbo/Public/Utility/Export-YarboSupportBundle.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Exports a redacted MQTT/connection bundle for support (e.g. GlitchTip or maintainers).
 
@@ -100,12 +100,12 @@ function Export-YarboSupportBundle {
                 }
             }
             $bundle.Recording = [ordered]@{
-                RecordedAt       = $raw.RecordedAt
-                Broker           = $raw.Broker
-                Port             = $raw.Port
-                DurationSeconds  = $raw.DurationSeconds
-                MessageCount     = $messages.Count
-                Topics           = [ordered]@{}
+                RecordedAt        = $raw.RecordedAt
+                Broker            = $raw.Broker
+                Port              = $raw.Port
+                DurationSeconds   = $raw.DurationSeconds
+                MessageCount      = $messages.Count
+                Topics            = [ordered]@{}
                 DecodedKeysSample = [ordered]@{}
             }
             foreach ($t in ($byTopic.Keys | Sort-Object)) { $bundle.Recording.Topics[$t] = $byTopic[$t] }
@@ -118,10 +118,10 @@ function Export-YarboSupportBundle {
         $cmdArr = $Connection.CommandLog.ToArray() | Select-Object -Last $CommandLogEntries
         $telArr = $Connection.TelemetryLog.ToArray() | Select-Object -Last $TelemetryLogEntries
         $bundle.ConnectionLog = [ordered]@{
-            Broker        = $Connection.Broker
-            Port          = $Connection.Port
-            SerialNumber  = $Connection.SerialNumber
-            CommandLog    = @($cmdArr | ForEach-Object {
+            Broker       = $Connection.Broker
+            Port         = $Connection.Port
+            SerialNumber = $Connection.SerialNumber
+            CommandLog   = @($cmdArr | ForEach-Object {
                     $entry = [ordered]@{
                         Timestamp = $_.Timestamp.ToString('o')
                         Command   = $_.Command

--- a/src/PSYarbo/Public/Utility/Get-YarboMqttRecordingReport.ps1
+++ b/src/PSYarbo/Public/Utility/Get-YarboMqttRecordingReport.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Analyzes an MQTT recording file and reports which topics are exposed by which cmdlets.
+
+.DESCRIPTION
+    Reads a JSON recording produced by Invoke-YarboMqttSniff -RecordPath (or Record-YarboMqtt.ps1).
+    For meaningful coverage, use a recording of real MQTT from your robot, not synthetic/fixture data.
+    Decodes zlib payloads where possible, groups by topic pattern, and outputs a coverage report:
+    which MQTT topics were seen and which PSYarbo cmdlets expose that data.
+
+.PARAMETER RecordingPath
+    Path to the JSON recording file (from Invoke-YarboMqttSniff -RecordPath).
+
+.PARAMETER OutPath
+    If set, write the report to this file as well as the console.
+
+.EXAMPLE
+    Invoke-YarboMqttSniff -Broker 192.0.2.1 -DurationSeconds 60 -RecordPath ./mqtt-recording.json
+    Get-YarboMqttRecordingReport -RecordingPath ./mqtt-recording.json
+#>
+function Get-YarboMqttRecordingReport {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('Path')]
+        [string]$RecordingPath,
+
+        [string]$OutPath
+    )
+
+    if (-not (Test-Path -LiteralPath $RecordingPath)) {
+        $PSCmdlet.WriteError([System.Management.Automation.ErrorRecord]::new(
+            [System.IO.FileNotFoundException]::new("Recording not found.", $RecordingPath),
+            'PSYarbo.RecordingNotFound',
+            [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+            $RecordingPath
+        ))
+        return
+    }
+
+    $raw = Get-Content -LiteralPath $RecordingPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $messages = @($raw.Messages)
+    if ($messages.Count -eq 0) {
+        Write-Host "Recording has 0 messages. Nothing to report."
+        return
+    }
+
+    # Topic suffix (e.g. device/DeviceMSG) -> cmdlets that expose this data
+    $topicToCmdlets = @{
+        'device/DeviceMSG'       = @('Get-YarboStatus', 'Get-YarboRobot', 'Get-YarboTelemetry', 'Watch-YarboTelemetry')
+        'device/heart_beat'      = @('Watch-YarboTelemetry -IncludeHeartbeat', 'Connection.LastHeartbeat / LastWorkingState')
+        'device/data_feedback'   = @('(command responses) Get-YarboPlan', 'Get-YarboStatus', 'Get-YarboGlobalParams', 'Get-YarboSchedule', 'etc.')
+        'device/plan_feedback'   = @('Watch-YarboTelemetry -IncludePlanFeedback', 'Connection.LastPlanFeedback')
+        'device/recharge_feedback' = @('Watch-YarboTelemetry', 'Connection.LastRechargeFeedback')
+    }
+
+    $bySuffix = @{}
+    $decodedSamples = @{}
+    foreach ($m in $messages) {
+        $topic = $m.Topic
+        $suffix = $null
+        if ($topic -match 'snowbot/[^/]+/(.+)$') { $suffix = $Matches[1] }
+        elseif ($topic -match '^(.+)$') { $suffix = $topic }
+        if (-not $suffix) { continue }
+        if (-not $bySuffix[$suffix]) { $bySuffix[$suffix] = 0; $decodedSamples[$suffix] = $null }
+        $bySuffix[$suffix]++
+
+        if (-not $decodedSamples[$suffix] -and $m.PayloadBase64) {
+            try {
+                $bytes = [Convert]::FromBase64String($m.PayloadBase64)
+                $decoded = ConvertFrom-ZlibPayload -Data $bytes
+                if ($decoded) { $decodedSamples[$suffix] = $decoded }
+            } catch { $null = $_ }
+        }
+    }
+
+    $reportLines = [System.Collections.Generic.List[string]]::new()
+    $reportLines.Add("=== MQTT recording report: $RecordingPath ===")
+    $reportLines.Add("Recorded: $($raw.RecordedAt) | Broker: $($raw.Broker):$($raw.Port) | Duration: $($raw.DurationSeconds)s | Messages: $($raw.MessageCount)")
+    $reportLines.Add("")
+    $reportLines.Add("--- Topics seen (suffix) | Count | Exposed by cmdlets ---")
+
+    $covered = [System.Collections.Generic.List[string]]::new()
+    $gaps = [System.Collections.Generic.List[string]]::new()
+    foreach ($suffix in ($bySuffix.Keys | Sort-Object)) {
+        $count = $bySuffix[$suffix]
+        $cmdlets = $topicToCmdlets[$suffix]
+        if ($cmdlets) {
+            $covered.Add($suffix)
+            $reportLines.Add("  $suffix | $count | $($cmdlets -join ', ')")
+        } else {
+            $gaps.Add($suffix)
+            $reportLines.Add("  $suffix | $count | (no cmdlet mapping - consider adding support)")
+        }
+    }
+
+    $reportLines.Add("")
+    $reportLines.Add("--- Decoded payload sample keys (first message per topic) ---")
+    foreach ($suffix in ($decodedSamples.Keys | Sort-Object)) {
+        $sample = $decodedSamples[$suffix]
+        if ($sample -is [PSCustomObject]) {
+            $keys = ($sample.PSObject.Properties | ForEach-Object { $_.Name }) -join ', '
+            $reportLines.Add("  $suffix : $keys")
+        } else {
+            $reportLines.Add("  $suffix : (decode failed or empty)")
+        }
+    }
+
+    $reportLines.Add("")
+    $reportLines.Add("--- Summary ---")
+    $reportLines.Add("  Topics with cmdlet coverage: $($covered.Count)")
+    if ($gaps.Count -gt 0) {
+        $reportLines.Add("  Topics not yet mapped to cmdlets: $($gaps -join ', ')")
+    } else {
+        $reportLines.Add("  All observed topics have cmdlet coverage.")
+    }
+
+    $text = $reportLines -join [Environment]::NewLine
+    Write-Host $text
+
+    if ($OutPath) {
+        $dir = Split-Path -Parent $OutPath
+        if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        $text | Set-Content -LiteralPath $OutPath -Encoding UTF8
+        Write-Verbose "Report written to $OutPath"
+    }
+
+    [PSCustomObject]@{
+        RecordingPath   = $RecordingPath
+        MessageCount    = $raw.MessageCount
+        TopicsSeen      = @($bySuffix.Keys)
+        TopicsCovered   = @($covered)
+        TopicsNotMapped = @($gaps)
+        ReportText      = $text
+    }
+}

--- a/src/PSYarbo/Public/Utility/Get-YarboMqttRecordingReport.ps1
+++ b/src/PSYarbo/Public/Utility/Get-YarboMqttRecordingReport.ps1
@@ -31,11 +31,11 @@ function Get-YarboMqttRecordingReport {
 
     if (-not (Test-Path -LiteralPath $RecordingPath)) {
         $PSCmdlet.WriteError([System.Management.Automation.ErrorRecord]::new(
-            [System.IO.FileNotFoundException]::new("Recording not found.", $RecordingPath),
-            'PSYarbo.RecordingNotFound',
-            [System.Management.Automation.ErrorCategory]::ObjectNotFound,
-            $RecordingPath
-        ))
+                [System.IO.FileNotFoundException]::new("Recording not found.", $RecordingPath),
+                'PSYarbo.RecordingNotFound',
+                [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                $RecordingPath
+            ))
         return
     }
 
@@ -48,10 +48,10 @@ function Get-YarboMqttRecordingReport {
 
     # Topic suffix (e.g. device/DeviceMSG) -> cmdlets that expose this data
     $topicToCmdlets = @{
-        'device/DeviceMSG'       = @('Get-YarboStatus', 'Get-YarboRobot', 'Get-YarboTelemetry', 'Watch-YarboTelemetry')
-        'device/heart_beat'      = @('Watch-YarboTelemetry -IncludeHeartbeat', 'Connection.LastHeartbeat / LastWorkingState')
-        'device/data_feedback'   = @('(command responses) Get-YarboPlan', 'Get-YarboStatus', 'Get-YarboGlobalParams', 'Get-YarboSchedule', 'etc.')
-        'device/plan_feedback'   = @('Watch-YarboTelemetry -IncludePlanFeedback', 'Connection.LastPlanFeedback')
+        'device/DeviceMSG'         = @('Get-YarboStatus', 'Get-YarboRobot', 'Get-YarboTelemetry', 'Watch-YarboTelemetry')
+        'device/heart_beat'        = @('Watch-YarboTelemetry -IncludeHeartbeat', 'Connection.LastHeartbeat / LastWorkingState')
+        'device/data_feedback'     = @('(command responses) Get-YarboPlan', 'Get-YarboStatus', 'Get-YarboGlobalParams', 'Get-YarboSchedule', 'etc.')
+        'device/plan_feedback'     = @('Watch-YarboTelemetry -IncludePlanFeedback', 'Connection.LastPlanFeedback')
         'device/recharge_feedback' = @('Watch-YarboTelemetry', 'Connection.LastRechargeFeedback')
     }
 

--- a/src/PSYarbo/en-US/about_PSYarbo.help.txt
+++ b/src/PSYarbo/en-US/about_PSYarbo.help.txt
@@ -18,7 +18,7 @@ LONG DESCRIPTION
     QUICK START
 
         # Connect to your robot
-        Connect-Yarbo -Broker 192.168.1.24 -SerialNumber 24400102L8HO5227
+        Connect-Yarbo -Broker <rover-ip> -SerialNumber <serial-number>
 
         # Check status
         Get-YarboStatus

--- a/src/PSYarbo/en-US/about_PSYarbo.help.txt
+++ b/src/PSYarbo/en-US/about_PSYarbo.help.txt
@@ -44,8 +44,18 @@ LONG DESCRIPTION
     CONFIGURATION
 
         1. Explicit cmdlet parameters
-        2. Environment variables ($env:YARBO_BROKER, etc.)
-        3. Module defaults
+        2. Environment variables ($env:YARBO_BROKER, $env:YARBO_SN, $env:YARBO_PORT, $env:YARBO_EMAIL)
+        3. Config file (~/.psyarbo/config.json)
+        4. Module defaults
+
+    CLOUD CREDENTIALS (SecretManagement)
+
+        Connect-YarboCloud integrates with Microsoft.PowerShell.SecretManagement when available.
+        On successful login, credentials are stored keyed by email (password and refresh token).
+        On subsequent sessions, Connect-YarboCloud -Email <email> (without -Password) retrieves
+        stored credentials so you can reconnect without re-entering the password.
+        If SecretManagement is not installed, a file-based fallback (~/.psyarbo/credentials.json)
+        is used. Use a SecretManagement vault named 'PSYarbo' for secure storage.
 
 SEE ALSO
     about_PSYarbo_MQTT

--- a/src/PSYarbo/en-US/about_PSYarbo.help.txt
+++ b/src/PSYarbo/en-US/about_PSYarbo.help.txt
@@ -57,7 +57,15 @@ LONG DESCRIPTION
         If SecretManagement is not installed, a file-based fallback (~/.psyarbo/credentials.json)
         is used. Use a SecretManagement vault named 'PSYarbo' for secure storage.
 
+    DEBUG LOGGING AND SUPPORT BUNDLES
+
+        To see what is sent and received over MQTT, use -Debug on any MQTT cmdlet or set
+        $env:PSYARBO_DEBUG = "1". To export a redacted support bundle for GlitchTip or
+        issue reports, use Export-YarboSupportBundle. See about_PSYarbo_Debug for full
+        documentation.
+
 SEE ALSO
     about_PSYarbo_MQTT
+    about_PSYarbo_Debug
     Connect-Yarbo
     Connect-YarboCloud

--- a/src/PSYarbo/en-US/about_PSYarbo_Debug.help.txt
+++ b/src/PSYarbo/en-US/about_PSYarbo_Debug.help.txt
@@ -1,0 +1,107 @@
+TOPIC
+    about_PSYarbo_Debug
+
+SHORT DESCRIPTION
+    Debug logging and support bundles for troubleshooting MQTT and reporting issues.
+
+LONG DESCRIPTION
+    PSYarbo provides debug output and a support-bundle export so you can see
+    exactly what is sent and received over MQTT, and share redacted dumps with
+    maintainers or GlitchTip. This aligns with the Debug Logging feature in
+    python-yarbo (see GitHub issue #59).
+
+    WHEN TO USE
+        - Troubleshooting firmware versions or heads/attachments you cannot test yourself
+        - Seeing the raw MQTT command and response for a single call
+        - Preparing a "full MQTT dump" for an issue report or GlitchTip
+
+    DEBUG LOGGING (WHAT IS SENT AND RECEIVED)
+
+        You can enable debug output in two ways:
+
+        1. -Debug switch (per command)
+           Pass the common -Debug parameter to any cmdlet that uses MQTT.
+           PowerShell sets $DebugPreference to 'Continue' for that command only,
+           so you see Write-Debug output (topic, payload, response).
+
+           Example:
+             Get-YarboStatus -Debug
+             Send-YarboCommand -Command read_global_params -Debug
+
+        2. Environment variable PSYARBO_DEBUG (session-wide)
+           Set $env:PSYARBO_DEBUG = "1" or $env:PSYARBO_DEBUG = "true" so that
+           every MQTT send/receive prints without passing -Debug each time.
+           Output is written to the information stream so it appears in the console.
+
+           Example:
+             $env:PSYARBO_DEBUG = "1"
+             Get-YarboStatus
+             Send-YarboCommand -Command get_device_msg
+
+        OUTPUT FORMAT
+            By default, payloads are shown in human-readable form:
+              - Sent: topic and JSON payload (decoded)
+              - Received: topic, state, message, and optional data
+
+            For raw (base64) payloads instead of JSON, set:
+              $env:PSYARBO_DEBUG_RAW = "1"
+            or "true". This shows the zlib-compressed bytes as base64.
+
+        REDACTION
+            All debug and support-bundle output is passed through Protect-YarboLogMessage.
+            JWT tokens, Authorization headers, refresh_token, accessToken, and password
+            fields are redacted before being written.
+
+    SUPPORT BUNDLE (FULL MQTT DUMP FOR GLITCHTIP / ISSUES)
+
+        Export-YarboSupportBundle produces a redacted JSON file you can attach to
+        an issue or upload to GlitchTip. It does not contain raw payload bodies
+        or credentials; it includes topic lists, message counts, decoded payload
+        keys (for recordings), and recent CommandLog/TelemetryLog entries.
+
+        SOURCES
+            -RecordingPath  Path to a recording file from Invoke-YarboMqttSniff -RecordPath.
+                            The bundle will include topic counts and decoded key
+                            samples per topic (values redacted).
+
+            -Connection     A YarboConnection. The bundle will include the last N
+                            CommandLog and TelemetryLog entries (default 100 and 50).
+                            No raw payloads are stored in those logs, so this is safe.
+
+        You must provide at least one of -RecordingPath or -Connection.
+
+        PARAMETERS
+            -Path                 (required) Output JSON file path.
+            -RecordingPath        Recording from Invoke-YarboMqttSniff -RecordPath.
+            -Connection          Connection to export recent logs from.
+            -CommandLogEntries    When using -Connection, how many CommandLog entries (default 100).
+            -TelemetryLogEntries  When using -Connection, how many TelemetryLog entries (default 50).
+
+        EXAMPLES
+            # From an MQTT recording
+            Invoke-YarboMqttSniff -Broker 192.0.2.1 -DurationSeconds 60 -RecordPath ./recording.json
+            Export-YarboSupportBundle -Path ./support-bundle.json -RecordingPath ./recording.json
+
+            # From the current connection (after running some commands)
+            $conn = Connect-Yarbo -Broker 192.0.2.1 -SerialNumber YB123
+            Get-YarboStatus -Connection $conn
+            Export-YarboSupportBundle -Path ./support-bundle.json -Connection $conn
+
+            # Both sources
+            Export-YarboSupportBundle -Path ./bundle.json -RecordingPath ./recording.json -Connection $conn
+
+        After generating the file, attach it to your GitHub issue or upload to
+        your GlitchTip project as needed.
+
+    RELATED CMDLETS
+        Get-YarboLog              View in-memory CommandLog and TelemetryLog.
+        Invoke-YarboMqttSniff     Capture MQTT traffic to a file (-RecordPath).
+        Get-YarboMqttRecordingReport  Report topic coverage from a recording.
+
+SEE ALSO
+    about_PSYarbo
+    about_PSYarbo_MQTT
+    Export-YarboSupportBundle
+    Get-YarboLog
+    Invoke-YarboMqttSniff
+    https://github.com/markus-lassfolk/python-yarbo/issues/59

--- a/src/PSYarbo/en-US/about_PSYarbo_Heads.help.txt
+++ b/src/PSYarbo/en-US/about_PSYarbo_Heads.help.txt
@@ -1,0 +1,44 @@
+Topic
+    about_PSYarbo_Heads
+
+Short Description
+    Head type values and LED channel reference (aligned with python-yarbo).
+
+Long Description
+    The robot reports the attached head in Get-YarboStatus / Get-YarboRobot
+    as HeadType (integer). The following values are used by the firmware
+    (aligned with python-yarbo and home-assistant-yarbo):
+
+    HeadType  Name
+    -------   ----
+    0         NoHead
+    1         SnowBlower
+    2         LeafBlower
+    3         LawnMower
+    4         SmartCover (SAM)
+    5         LawnMowerPro
+    99        Trimmer
+
+    Some cmdlets are only applicable to certain heads (e.g. Set-YarboChute
+    and Set-YarboBladeSpeed). Check each cmdlet's help for head requirements.
+
+    LED channels (YarboLightState / Set-YarboLight)
+    -----------------------------------------------
+    The robot has 7 independent LED channels (0-255). Names match the
+    light_ctrl MQTT payload and python-yarbo YarboLightState:
+
+    HeadLight     led_head      Front/head white
+    LeftWhite     led_left_w    Left fill (white)
+    RightWhite    led_right_w   Right fill (white)
+    BodyLeftRed   body_left_r   Left body accent (red)
+    BodyRightRed  body_right_r  Right body accent (red)
+    TailLeftRed   tail_left_r   Left tail (red)
+    TailRightRed  tail_right_r  Right tail (red)
+
+    Use [YarboLightState]::AllOn(), ::AllOff(), or ::BodyOn() for presets.
+
+See Also
+    Get-YarboStatus
+    Set-YarboLight
+    about_PSYarbo
+    about_PSYarbo_MQTT

--- a/src/PSYarbo/en-US/about_PSYarbo_MQTT.help.txt
+++ b/src/PSYarbo/en-US/about_PSYarbo_MQTT.help.txt
@@ -82,6 +82,7 @@ LONG DESCRIPTION
 
 SEE ALSO
     about_PSYarbo
+    about_PSYarbo_Debug
     Connect-Yarbo
     Find-Yarbo
     Send-YarboCommand

--- a/tests/Fixtures/cloud-api-responses/getLatestPubVersion.json
+++ b/tests/Fixtures/cloud-api-responses/getLatestPubVersion.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.2.3",
+  "releaseNotes": "Fixture for unit tests"
+}

--- a/tests/Fixtures/cloud-api-responses/getUserRobotBindVos.json
+++ b/tests/Fixtures/cloud-api-responses/getUserRobotBindVos.json
@@ -1,0 +1,9 @@
+{
+  "deviceList": [
+    {
+      "sn": "ROBOT-SN-001",
+      "name": "My Yarbo",
+      "model": "Yarbo S1"
+    }
+  ]
+}

--- a/tests/Fixtures/cloud-api-responses/login.json
+++ b/tests/Fixtures/cloud-api-responses/login.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "code": 0,
+  "message": "success",
+  "data": {
+    "accessToken": "fixture-access-token",
+    "refreshToken": "fixture-refresh-token",
+    "expiresIn": 7200,
+    "snList": ["ROBOT-SN-001"]
+  }
+}

--- a/tests/Fixtures/data_feedback-samples/get_connect_wifi_name.json
+++ b/tests/Fixtures/data_feedback-samples/get_connect_wifi_name.json
@@ -1,0 +1,1 @@
+{"topic":"get_connect_wifi_name","state":0,"msg":"success","data":{"ssid":"MyWiFi"}}

--- a/tests/Fixtures/data_feedback-samples/read_global_params.json
+++ b/tests/Fixtures/data_feedback-samples/read_global_params.json
@@ -1,0 +1,1 @@
+{"topic":"read_global_params","state":0,"msg":"success","data":{"mow_speed":0.4,"cutting_height":50,"rain_delay":60,"obstacle_sensitivity":2,"timestamp":1771943320}}

--- a/tests/Fixtures/data_feedback-samples/read_schedules.json
+++ b/tests/Fixtures/data_feedback-samples/read_schedules.json
@@ -1,0 +1,1 @@
+{"topic":"read_schedules","state":0,"msg":"success","data":[{"id":1,"name":"Morning","plan_id":1,"enable":true,"schedule_type":0,"start_time":"08:00","end_time":"10:00","week_day":127,"interval_time":0,"is_weather_schedule":false,"return_method":0,"times":1,"timezone":"Europe/Stockholm"}]}

--- a/tests/Helpers/MockMqttClient.ps1
+++ b/tests/Helpers/MockMqttClient.ps1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
-    Mock MQTT client and YarboConnection factory for unit tests.
+    Mock MQTT client and YarboConnection factory for unit tests (§8.3).
 .DESCRIPTION
     Provides New-MockYarboConnection which creates a YarboConnection wired
-    to an in-memory fake MQTT client. Tests can:
-      - Enqueue responses into the ResponseQueue directly
-      - Enqueue push events into the TelemetryQueue directly
-      - Inspect what was published via $conn.__PublishedMessages
+    to an in-memory fake MQTT client (duck-typed; no real IMqttClient). Tests can:
+      - Inspect published messages via $conn.__PublishedMessages
+      - Simulate responses via Push-MockCommandResponse (topic → payload)
+      - Simulate push telemetry via Push-MockTelemetryEvent
     No network connection is required.
 #>
 

--- a/tests/Integration/FindConnectGetYarbo.Integration.Tests.ps1
+++ b/tests/Integration/FindConnectGetYarbo.Integration.Tests.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Integration tests: Find Yarbo, Connect, then run all local Get-Yarbo* cmdlets.
+    Run on a machine that can reach the robot (e.g. Windows on same LAN as the mower).
+    The robot should be powered on; if it is sleeping, the test tries Resume-Yarbo after connect.
+    Skip integration in CI: Invoke-Pester ./tests -ExcludeTag Integration
+    Run only this file: Invoke-Pester ./tests/Integration/FindConnectGetYarbo.Integration.Tests.ps1
+#>
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    $manifestPath = Join-Path $moduleRoot 'PSYarbo.psd1'
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+    Import-Module -Name $manifestPath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Find-Yarbo and Connect-Yarbo' -Tag Integration {
+    It 'Find-Yarbo returns at least one YarboRobot' {
+        $found = Find-Yarbo -TimeoutSeconds 8 -ErrorAction Stop
+        $found | Should -Not -BeNullOrEmpty
+        $found[0].SerialNumber | Should -Not -BeNullOrEmpty
+        $found[0].Broker | Should -Not -BeNullOrEmpty
+        $found[0].PSObject.TypeNames[0] | Should -BeLike '*YarboRobot*'
+    }
+
+    It 'Connect-Yarbo succeeds with first Find-Yarbo result' {
+        $robot = Find-Yarbo -TimeoutSeconds 8 -ErrorAction Stop | Select-Object -First 1
+        $robot | Should -Not -BeNullOrEmpty
+        $conn = $robot | Connect-Yarbo -TimeoutSeconds 10 -ErrorAction Stop
+        $conn | Should -Not -BeNullOrEmpty
+        $conn.Broker | Should -Be $robot.Broker
+        $conn.SerialNumber | Should -Be $robot.SerialNumber
+        $conn.PSObject.TypeNames[0] | Should -BeLike '*YarboConnection*'
+        $script:YarboConnection = $conn
+    }
+}
+
+Describe 'Get-Yarbo* (local MQTT)' -Tag Integration {
+    BeforeAll {
+        if (-not $script:YarboConnection) {
+            $robot = Find-Yarbo -TimeoutSeconds 8 -ErrorAction Stop | Select-Object -First 1
+            $script:YarboConnection = $robot | Connect-Yarbo -TimeoutSeconds 10 -ErrorAction Stop
+        }
+        $script:Conn = $script:YarboConnection
+        # Wake robot if it was sleeping (controller timed out); then allow a short delay for it to respond
+        Resume-Yarbo -Connection $script:Conn -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 4
+    }
+
+    It 'Get-YarboStatus returns YarboRobot with expected properties' {
+        $status = Get-YarboStatus -Connection $script:Conn -ErrorAction Stop
+        $status | Should -Not -BeNullOrEmpty
+        $status.PSObject.TypeNames[0] | Should -BeLike '*YarboRobot*'
+        $status.SerialNumber | Should -Not -BeNullOrEmpty
+        $status.PSObject.Properties['Battery'] | Should -Not -BeNullOrEmpty
+        $status.PSObject.Properties['State'] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Get-YarboRobot returns YarboRobot' {
+        $r = Get-YarboRobot -Connection $script:Conn -ErrorAction Stop
+        $r | Should -Not -BeNullOrEmpty
+        $r.PSObject.TypeNames[0] | Should -BeLike '*YarboRobot*'
+    }
+
+    It 'Get-YarboBattery returns a numeric value' {
+        $bat = Get-YarboBattery -Connection $script:Conn -ErrorAction Stop
+        $bat | Should -Not -BeNullOrEmpty
+        $bat | Should -BeIn (0..100)
+    }
+
+    It 'Get-YarboFirmware returns an object with version info' {
+        $fw = Get-YarboFirmware -Connection $script:Conn -ErrorAction Stop
+        $fw | Should -Not -BeNullOrEmpty
+        $fw.PSObject.Properties | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Get-YarboGlobalParams returns an object' {
+        $gp = Get-YarboGlobalParams -Connection $script:Conn -ErrorAction Stop
+        $gp | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Get-YarboMap returns map data (or empty if no map)' {
+        $map = Get-YarboMap -Connection $script:Conn -ErrorAction SilentlyContinue
+        # May be null/empty if robot has no map
+        if ($map) {
+            $map.PSObject.Properties | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-YarboPlan returns plan list (array)' {
+        $plans = Get-YarboPlan -Connection $script:Conn -ErrorAction Stop
+        $plans | Should -Not -BeNullOrEmpty
+        $plans -is [Array] | Should -BeTrue
+        if ($plans.Count -gt 0) {
+            $plans[0].PSObject.TypeNames[0] | Should -BeLike '*YarboPlan*'
+        }
+    }
+
+    It 'Get-YarboSchedule returns schedule list (array or empty)' {
+        $schedules = Get-YarboSchedule -Connection $script:Conn -ErrorAction SilentlyContinue
+        if ($null -eq $schedules) { $schedules = @() }
+        $schedules -is [Array] | Should -BeTrue
+        if ($schedules.Count -gt 0) {
+            $schedules[0].PSObject.TypeNames[0] | Should -BeLike '*YarboSchedule*'
+        }
+    }
+
+    It 'Get-YarboTelemetry returns YarboTelemetry' {
+        $tel = Get-YarboTelemetry -Connection $script:Conn -ErrorAction Stop
+        $tel | Should -Not -BeNullOrEmpty
+        $tel.PSObject.TypeNames[0] | Should -BeLike '*YarboTelemetry*'
+        $tel.PSObject.Properties['Battery'] | Should -Not -BeNullOrEmpty
+        $tel.PSObject.Properties['State'] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Get-YarboLog returns log entries (array)' {
+        $log = Get-YarboLog -Connection $script:Conn -Last 5 -ErrorAction Stop
+        $log | Should -Not -BeNullOrEmpty
+        $log -is [Array] | Should -BeTrue
+    }
+}
+
+Describe 'Disconnect-Yarbo' -Tag Integration {
+    It 'Disconnect-Yarbo runs without error' {
+        if ($script:YarboConnection) {
+            { Disconnect-Yarbo -Connection $script:YarboConnection -ErrorAction Stop } | Should -Not -Throw
+            $script:YarboConnection = $null
+        }
+    }
+}

--- a/tests/Integration/Get-YarboPlan.Tests.ps1
+++ b/tests/Integration/Get-YarboPlan.Tests.ps1
@@ -1,0 +1,36 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Integration tests for Get-YarboPlan using mocked MQTT (no real robot).
+    Tag: Mocked
+#>
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+    Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
+    . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+}
+
+InModuleScope PSYarbo {
+    Describe 'Get-YarboPlan (mocked MQTT)' -Tag Mocked {
+        It 'Returns YarboPlan array when Send-MqttCommand returns read_all_plan fixture' {
+            $conn = New-MockYarboConnection -SerialNumber 'MOCK-SN'
+            $planData = Get-Content (Join-Path $fixturesDir 'data_feedback-samples' 'read_all_plan.json') -Raw | ConvertFrom-Json
+            Mock Send-MqttCommand -ModuleName PSYarbo -ParameterFilter { $Command -eq 'read_all_plan' } {
+                return [YarboCommandResult]::new([PSCustomObject]@{ topic = 'read_all_plan'; state = 0; msg = 'success'; data = $planData.data })
+            }
+            $script:DefaultConnection = $conn
+            try {
+                $plans = Get-YarboPlan -Connection $conn
+                $plans | Should -Not -BeNullOrEmpty
+                $plans.Count | Should -BeGreaterThan 0
+                $plans[0].Name | Should -Not -BeNullOrEmpty
+            } finally {
+                $script:DefaultConnection = $null
+            }
+        }
+    }
+}

--- a/tests/Integration/Get-YarboPlan.Tests.ps1
+++ b/tests/Integration/Get-YarboPlan.Tests.ps1
@@ -6,15 +6,16 @@
     Tag: Mocked
 #>
 
-BeforeAll {
-    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
-    $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
-    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
-    Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
-    . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
-}
+$moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
 
 InModuleScope PSYarbo {
+    BeforeAll {
+        $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
+        . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+    }
+
     Describe 'Get-YarboPlan (mocked MQTT)' -Tag Mocked {
         It 'Returns YarboPlan array when Send-MqttCommand returns read_all_plan fixture' {
             $conn = New-MockYarboConnection -SerialNumber 'MOCK-SN'

--- a/tests/Integration/Get-YarboStatus.Tests.ps1
+++ b/tests/Integration/Get-YarboStatus.Tests.ps1
@@ -21,7 +21,7 @@ InModuleScope PSYarbo {
                 $status = Get-YarboStatus -Connection $conn
                 $status | Should -Not -BeNullOrEmpty
                 $status.SerialNumber | Should -Be 'MOCK-SN'
-                $status.Battery | Should -Be 83
+                $status.Battery | Should -Be '83%'
             } finally {
                 $script:DefaultConnection = $null
             }

--- a/tests/Integration/Get-YarboStatus.Tests.ps1
+++ b/tests/Integration/Get-YarboStatus.Tests.ps1
@@ -1,0 +1,30 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+    Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
+    . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+}
+InModuleScope PSYarbo {
+    Describe 'Get-YarboStatus (mocked MQTT)' -Tag Mocked {
+        It 'Returns YarboRobot when Send-MqttCommand returns fixture data' {
+            $conn = New-MockYarboConnection -SerialNumber 'MOCK-SN' -Broker '192.0.2.1'
+            $deviceMsg = Get-Content (Join-Path $fixturesDir 'DeviceMSG-sample.json') -Raw | ConvertFrom-Json
+            $feedback = [PSCustomObject]@{ topic = 'get_device_msg'; state = 0; msg = 'success'; data = $deviceMsg }
+            Mock Send-MqttCommand -ModuleName PSYarbo -ParameterFilter { $Command -eq 'get_device_msg' } {
+                return [YarboCommandResult]::new($feedback)
+            }
+            $script:DefaultConnection = $conn
+            try {
+                $status = Get-YarboStatus -Connection $conn
+                $status | Should -Not -BeNullOrEmpty
+                $status.SerialNumber | Should -Be 'MOCK-SN'
+                $status.Battery | Should -Be 83
+            } finally {
+                $script:DefaultConnection = $null
+            }
+        }
+    }
+}

--- a/tests/Integration/Get-YarboStatus.Tests.ps1
+++ b/tests/Integration/Get-YarboStatus.Tests.ps1
@@ -1,13 +1,15 @@
 #Requires -Version 7.4
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-BeforeAll {
-    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
-    $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
-    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
-    Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
-    . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
-}
+$moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
+
 InModuleScope PSYarbo {
+    BeforeAll {
+        $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
+        . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+    }
+
     Describe 'Get-YarboStatus (mocked MQTT)' -Tag Mocked {
         It 'Returns YarboRobot when Send-MqttCommand returns fixture data' {
             $conn = New-MockYarboConnection -SerialNumber 'MOCK-SN' -Broker '192.0.2.1'
@@ -21,7 +23,7 @@ InModuleScope PSYarbo {
                 $status = Get-YarboStatus -Connection $conn
                 $status | Should -Not -BeNullOrEmpty
                 $status.SerialNumber | Should -Be 'MOCK-SN'
-                $status.Battery | Should -Be '83%'
+                $status.BatteryCapacity | Should -Be 83
             } finally {
                 $script:DefaultConnection = $null
             }

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -621,8 +621,8 @@ Describe 'Help Documentation' {
         foreach ($fn in $script:exportedFunctions) {
             $help = Get-Help $fn
             $examplesProp = $help.PSObject.Properties['examples']
-            $examples = if ($null -ne $examplesProp -and $help.examples) { @($help.examples.example) } else { @() }
-            $examples.Count | Should -BeGreaterThan 0 -Because "$fn should have at least one example"
+            $examples = if ($null -ne $examplesProp -and $help.examples -and $help.examples.example) { $help.examples.example } else { @() }
+            @($examples).Count | Should -BeGreaterThan 0 -Because "$fn should have at least one example"
         }
     }
 

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -63,7 +63,7 @@ Describe 'Module Manifest' {
             'Get-YarboMap', 'Get-YarboSchedule', 'Set-YarboSchedule',
             'Get-YarboTelemetry', 'Watch-YarboTelemetry', 'Export-YarboTelemetry',
             'Connect-YarboCloud', 'Get-YarboDevice', 'Get-YarboVideo', 'Get-YarboPlanHistory',
-            'Test-YarboConnection', 'Get-YarboLog'
+            'Test-YarboConnection', 'Get-YarboLog', 'Get-YarboMqttRecordingReport', 'Export-YarboSupportBundle'
         )
 
         foreach ($fn in $expected) {

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -620,7 +620,8 @@ Describe 'Help Documentation' {
     It 'Every exported function has at least one example' {
         foreach ($fn in $script:exportedFunctions) {
             $help = Get-Help $fn
-            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $hasExamplesProp = @($help.PSObject.Properties.Match('examples')).Count -gt 0 -and $help.examples
+            $examples = if ($hasExamplesProp) { $help.examples.example } else { @() }
             $examples.Count | Should -BeGreaterThan 0 -Because "$fn should have at least one example"
         }
     }

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -588,11 +588,11 @@ Describe 'Public Cmdlet Parameter Validation' {
     }
 
     Context 'Connect-YarboCloud' {
-        It 'Has non-mandatory Email parameter in Credential set' {
+        It 'Email in Credential set is optional (resolvable from env/config)' {
             $cmd = Get-Command Connect-YarboCloud
-            $emailParam = $cmd.Parameters['Email'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'Credential' }
-            $emailParam | Should -Not -BeNullOrEmpty
-            $emailParam.Mandatory | Should -BeFalse
+            $credSet = $cmd.Parameters['Email'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'Credential' }
+            $credSet | Should -Not -BeNullOrEmpty
+            $credSet.Mandatory | Should -BeFalse -Because 'Email can be resolved from $env:YARBO_EMAIL or config'
         }
 
         It 'Password is SecureString type' {

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'Module Manifest' {
             'Set-YarboLight', 'Start-YarboBuzzer', 'Stop-YarboBuzzer',
             'Start-YarboPlan', 'Stop-YarboPlan', 'Suspend-YarboPlan', 'Resume-YarboPlan',
             'Send-YarboCommand', 'Send-YarboReturnToDock',
-            'Set-YarboGlobalParams',
+            'Set-YarboGlobalParams', 'Set-YarboBladeSpeed', 'Set-YarboChargeLimit',
             'Resume-Yarbo', 'Suspend-Yarbo',
             'Start-YarboManualDrive', 'Set-YarboVelocity', 'Set-YarboRoller', 'Set-YarboChute', 'Stop-YarboManualDrive',
             'Get-YarboPlan', 'New-YarboPlan', 'Remove-YarboPlan',

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Module Manifest' {
 
         # Core cmdlets that must be present
         $expected = @(
-            'Connect-Yarbo', 'Disconnect-Yarbo', 'Find-Yarbo',
+            'Connect-Yarbo', 'Disconnect-Yarbo', 'Find-Yarbo', 'Find-YarboDevice',
             'Get-YarboStatus', 'Get-YarboRobot', 'Get-YarboBattery', 'Get-YarboFirmware',
             'Get-YarboGlobalParams',
             'Set-YarboLight', 'Start-YarboBuzzer', 'Stop-YarboBuzzer',
@@ -101,7 +101,7 @@ Describe 'Module Structure' {
 
     It 'Classes directory exists' {
         Join-Path $moduleRoot 'Classes' | Should -Exist
-        (Get-ChildItem -Path (Join-Path $moduleRoot 'Classes') -Filter '*.ps1').Count | Should -Be 9
+        (Get-ChildItem -Path (Join-Path $moduleRoot 'Classes') -Filter '*.ps1').Count | Should -Be 11
     }
 
     It 'Format file exists' {
@@ -231,10 +231,10 @@ Describe 'Classes' {
 
         It 'ToString formats correctly' {
             $conn = [YarboConnection]::new()
-            $conn.Broker = '192.168.1.24'
+            $conn.Broker = '192.168.0.1'
             $conn.Port = 1883
             $conn.SerialNumber = 'TEST123'
-            $conn.ToString() | Should -Be 'Yarbo[TEST123@192.168.1.24:1883]'
+            $conn.ToString() | Should -Be 'Yarbo[TEST123@192.168.0.1:1883]'
         }
     }
 
@@ -247,9 +247,9 @@ Describe 'Classes' {
         }
 
         It 'YarboConnectionException includes broker info' {
-            $ex = [YarboConnectionException]::new('Connection failed', '192.168.1.24')
-            $ex.Broker | Should -Be '192.168.1.24'
-            $ex.Remediation | Should -BeLike '*192.168.1.24*'
+            $ex = [YarboConnectionException]::new('Connection failed', '192.168.0.1')
+            $ex.Broker | Should -Be '192.168.0.1'
+            $ex.Remediation | Should -BeLike '*192.168.0.1*'
         }
 
         It 'YarboCommandException wraps result' {
@@ -370,7 +370,7 @@ Describe 'Private Functions' {
         }
 
         It 'Parses into YarboRobot' {
-            $r = ConvertTo-YarboRobot -DeviceMsg $fixture -SerialNumber 'TEST-SN' -Broker '192.168.1.24' -Port 1883
+            $r = ConvertTo-YarboRobot -DeviceMsg $fixture -SerialNumber 'TEST-SN' -Broker '192.168.0.1' -Port 1883
             $r.SerialNumber | Should -Be 'TEST-SN'
             $r.BatteryCapacity | Should -Be 83
             $r.HeadType | Should -Be 1
@@ -402,7 +402,7 @@ Describe 'Private Functions' {
         }
 
         It 'Passes through non-sensitive messages unchanged' {
-            $msg = "Connecting to 192.168.1.24:1883"
+            $msg = "Connecting to 192.168.0.1:1883"
             $redacted = Protect-YarboLogMessage -Message $msg
             $redacted | Should -Be $msg
         }

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -629,7 +629,6 @@ Describe 'Help Documentation' {
     }
 
 }
-}
 
 AfterAll {
     if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -620,10 +620,12 @@ Describe 'Help Documentation' {
     It 'Every exported function has at least one example' {
         foreach ($fn in $script:exportedFunctions) {
             $help = Get-Help $fn
-            $hasExamplesProp = @($help.PSObject.Properties.Match('examples')).Count -gt 0 -and $help.examples
-            $examples = if ($hasExamplesProp) { $help.examples.example } else { @() }
+            $examplesProp = $help.PSObject.Properties['examples']
+            $examples = if ($null -ne $examplesProp -and $help.examples) { @($help.examples.example) } else { @() }
             $examples.Count | Should -BeGreaterThan 0 -Because "$fn should have at least one example"
         }
+    }
+
     }
 
 }

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Module Manifest' {
 
         # Core cmdlets that must be present
         $expected = @(
-            'Connect-Yarbo', 'Disconnect-Yarbo', 'Find-Yarbo', 'Find-YarboDevice',
+            'Connect-Yarbo', 'Disconnect-Yarbo', 'Find-Yarbo', 'Find-YarboDevice', 'Invoke-YarboMqttSniff',
             'Get-YarboStatus', 'Get-YarboRobot', 'Get-YarboBattery', 'Get-YarboFirmware',
             'Get-YarboGlobalParams',
             'Set-YarboLight', 'Start-YarboBuzzer', 'Stop-YarboBuzzer',

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -588,10 +588,11 @@ Describe 'Public Cmdlet Parameter Validation' {
     }
 
     Context 'Connect-YarboCloud' {
-        It 'Has mandatory Email parameter in Credential set' {
+        It 'Has non-mandatory Email parameter in Credential set' {
             $cmd = Get-Command Connect-YarboCloud
-            $emailParam = $cmd.Parameters['Email'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'Credential' -and $_.Mandatory }
+            $emailParam = $cmd.Parameters['Email'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'Credential' }
             $emailParam | Should -Not -BeNullOrEmpty
+            $emailParam.Mandatory | Should -BeFalse
         }
 
         It 'Password is SecureString type' {

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -231,10 +231,10 @@ Describe 'Classes' {
 
         It 'ToString formats correctly' {
             $conn = [YarboConnection]::new()
-            $conn.Broker = '192.168.0.1'
+            $conn.Broker = '192.0.2.1'
             $conn.Port = 1883
             $conn.SerialNumber = 'TEST123'
-            $conn.ToString() | Should -Be 'Yarbo[TEST123@192.168.0.1:1883]'
+            $conn.ToString() | Should -Be 'Yarbo[TEST123@192.0.2.1:1883]'
         }
     }
 
@@ -247,9 +247,9 @@ Describe 'Classes' {
         }
 
         It 'YarboConnectionException includes broker info' {
-            $ex = [YarboConnectionException]::new('Connection failed', '192.168.0.1')
-            $ex.Broker | Should -Be '192.168.0.1'
-            $ex.Remediation | Should -BeLike '*192.168.0.1*'
+            $ex = [YarboConnectionException]::new('Connection failed', '192.0.2.1')
+            $ex.Broker | Should -Be '192.0.2.1'
+            $ex.Remediation | Should -BeLike '*192.0.2.1*'
         }
 
         It 'YarboCommandException wraps result' {
@@ -370,7 +370,7 @@ Describe 'Private Functions' {
         }
 
         It 'Parses into YarboRobot' {
-            $r = ConvertTo-YarboRobot -DeviceMsg $fixture -SerialNumber 'TEST-SN' -Broker '192.168.0.1' -Port 1883
+            $r = ConvertTo-YarboRobot -DeviceMsg $fixture -SerialNumber 'TEST-SN' -Broker '192.0.2.1' -Port 1883
             $r.SerialNumber | Should -Be 'TEST-SN'
             $r.BatteryCapacity | Should -Be 83
             $r.HeadType | Should -Be 1
@@ -402,7 +402,7 @@ Describe 'Private Functions' {
         }
 
         It 'Passes through non-sensitive messages unchanged' {
-            $msg = "Connecting to 192.168.0.1:1883"
+            $msg = "Connecting to 192.0.2.1:1883"
             $redacted = Protect-YarboLogMessage -Message $msg
             $redacted | Should -Be $msg
         }

--- a/tests/PSYarbo.Tests.ps1
+++ b/tests/PSYarbo.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'Classes' {
         $classFiles = @(
             'YarboExceptions', 'YarboLightState', 'YarboCommandResult',
             'YarboTelemetry', 'YarboPlan', 'YarboSchedule', 'YarboRobot',
-            'YarboConnection', 'YarboCloudSession'
+            'YarboConnection', 'YarboCloudSession', 'YarboGlobalParams', 'YarboEndpoint'
         )
         foreach ($class in $classFiles) {
             . (Join-Path $moduleRoot "Classes/$class.ps1")

--- a/tests/Unit/ControllerGuard.Tests.ps1
+++ b/tests/Unit/ControllerGuard.Tests.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Unit tests for ControllerGuard (Assert-YarboController).
+    Uses Mock Send-MqttCommand when run inside InModuleScope; requires full module load.
+#>
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+    Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
+    . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+}
+
+InModuleScope PSYarbo {
+    Describe 'Assert-YarboController' {
+        It 'Does nothing when ControllerAcquired is already true' {
+            $conn = New-MockYarboConnection -SerialNumber 'GUARD-SN'
+            $conn.ControllerAcquired = $true
+            { Assert-YarboController -Connection $conn } | Should -Not -Throw
+        }
+
+        It 'Sets ControllerAcquired when get_controller returns state 0' {
+            $conn = New-MockYarboConnection -SerialNumber 'GUARD-SN'
+            $conn.ControllerAcquired = $false
+            Mock Send-MqttCommand -ModuleName PSYarbo -Verifiable {
+                return [YarboCommandResult]::new([PSCustomObject]@{ topic = 'get_controller'; state = 0; msg = 'success'; data = $null })
+            }
+            { Assert-YarboController -Connection $conn } | Should -Not -Throw
+            $conn.ControllerAcquired | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/ControllerGuard.Tests.ps1
+++ b/tests/Unit/ControllerGuard.Tests.ps1
@@ -16,7 +16,6 @@ InModuleScope PSYarbo {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
     }
-
     Describe 'Assert-YarboController' {
         It 'Does nothing when ControllerAcquired is already true' {
             $conn = New-MockYarboConnection -SerialNumber 'GUARD-SN'

--- a/tests/Unit/ControllerGuard.Tests.ps1
+++ b/tests/Unit/ControllerGuard.Tests.ps1
@@ -10,10 +10,13 @@ BeforeAll {
     $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
     if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
     Import-Module (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
-    . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
 }
 
 InModuleScope PSYarbo {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+    }
+
     Describe 'Assert-YarboController' {
         It 'Does nothing when ControllerAcquired is already true' {
             $conn = New-MockYarboConnection -SerialNumber 'GUARD-SN'

--- a/tests/Unit/DebugAndSupportBundle.Tests.ps1
+++ b/tests/Unit/DebugAndSupportBundle.Tests.ps1
@@ -147,9 +147,10 @@ InModuleScope PSYarbo {
                     Broker    = '192.0.2.1:1883'
                 })
             $conn.TelemetryLog.Enqueue([PSCustomObject]@{
-                    At     = [datetime]::UtcNow
-                    Topic  = 'snowbot/BUNDLE-SN/device/DeviceMSG'
-                    Source = 'DeviceMSG'
+                    Timestamp   = [datetime]::UtcNow
+                    MessageType = 'DeviceMSG'
+                    Direction   = 'Pushed'
+                    Topic       = 'snowbot/BUNDLE-SN/device/DeviceMSG'
                 })
 
             $out = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-SupportBundle-$(Get-Random).json"

--- a/tests/Unit/DebugAndSupportBundle.Tests.ps1
+++ b/tests/Unit/DebugAndSupportBundle.Tests.ps1
@@ -1,0 +1,238 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+using module ../../src/PSYarbo/PSYarbo.psd1
+<#
+.SYNOPSIS
+    Unit tests for debug logging (PSYARBO_DEBUG, -Debug, raw) and Export-YarboSupportBundle.
+#>
+
+BeforeAll {
+    $moduleRoot  = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    $helpersDir  = Join-Path $PSScriptRoot '..' 'Helpers'
+    $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
+
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+    Import-Module -Name (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
+
+    $classFiles = @(
+        'YarboExceptions', 'YarboLightState', 'YarboCommandResult',
+        'YarboTelemetry', 'YarboPlan', 'YarboSchedule', 'YarboRobot',
+        'YarboConnection', 'YarboCloudSession'
+    )
+    foreach ($cf in $classFiles) { . (Join-Path $moduleRoot "Classes/$cf.ps1") }
+}
+
+InModuleScope PSYarbo {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+    }
+
+    Describe 'Debug mode helpers' {
+        Context 'Test-YarboDebugMode' {
+            It 'Returns false when DebugPreference is SilentlyContinue and env is not set' {
+                $env:PSYARBO_DEBUG = $null
+                $env:PSYARBO_DEBUG = ''
+                $prev = $DebugPreference
+                try {
+                    $DebugPreference = 'SilentlyContinue'
+                    Test-YarboDebugMode | Should -BeFalse
+                } finally {
+                    $DebugPreference = $prev
+                }
+            }
+
+            It 'Returns true when PSYARBO_DEBUG env is 1' {
+                $prev = $env:PSYARBO_DEBUG
+                try {
+                    $env:PSYARBO_DEBUG = '1'
+                    Test-YarboDebugMode | Should -BeTrue
+                } finally {
+                    $env:PSYARBO_DEBUG = $prev
+                }
+            }
+
+            It 'Returns true when PSYARBO_DEBUG env is true' {
+                $prev = $env:PSYARBO_DEBUG
+                try {
+                    $env:PSYARBO_DEBUG = 'true'
+                    Test-YarboDebugMode | Should -BeTrue
+                } finally {
+                    $env:PSYARBO_DEBUG = $prev
+                }
+            }
+
+            It 'Returns true when DebugPreference is Continue' {
+                $prev = $DebugPreference
+                $prevEnv = $env:PSYARBO_DEBUG
+                try {
+                    $env:PSYARBO_DEBUG = $null
+                    $DebugPreference = 'Continue'
+                    Test-YarboDebugMode | Should -BeTrue
+                } finally {
+                    $DebugPreference = $prev
+                    $env:PSYARBO_DEBUG = $prevEnv
+                }
+            }
+        }
+
+        Context 'Test-YarboDebugRaw' {
+            It 'Returns false when PSYARBO_DEBUG_RAW is not set' {
+                $prev = $env:PSYARBO_DEBUG_RAW
+                try {
+                    $env:PSYARBO_DEBUG_RAW = $null
+                    Test-YarboDebugRaw | Should -BeFalse
+                } finally {
+                    $env:PSYARBO_DEBUG_RAW = $prev
+                }
+            }
+
+            It 'Returns true when PSYARBO_DEBUG_RAW is 1' {
+                $prev = $env:PSYARBO_DEBUG_RAW
+                try {
+                    $env:PSYARBO_DEBUG_RAW = '1'
+                    Test-YarboDebugRaw | Should -BeTrue
+                } finally {
+                    $env:PSYARBO_DEBUG_RAW = $prev
+                }
+            }
+        }
+
+        Context 'Write-YarboDebugMessage' {
+            It 'Does not throw when given a normal message' {
+                { Write-YarboDebugMessage -Message 'Test debug line' } | Should -Not -Throw
+            }
+
+            It 'Redacts sensitive content in message (JWT)' {
+                $prev = $env:PSYARBO_DEBUG
+                try {
+                    $env:PSYARBO_DEBUG = '1'
+                    $info = @()
+                    $null = Get-Command Write-Information -ErrorAction SilentlyContinue
+                    # When env is set, Write-YarboDebugMessage uses Write-Information; we cannot easily capture it in Pester without redirecting.
+                    # So we only assert it doesn't throw and that Protect-YarboLogMessage is applied (tested in Log Redaction context elsewhere).
+                    { Write-YarboDebugMessage -Message 'Token: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0In0.sig' } | Should -Not -Throw
+                } finally {
+                    $env:PSYARBO_DEBUG = $prev
+                }
+            }
+        }
+    }
+
+    Describe 'Export-YarboSupportBundle' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Export-YarboSupportBundle' -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Path parameter' {
+            $cmd = Get-Command Export-YarboSupportBundle
+            $cmd.Parameters['Path'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Throws when neither RecordingPath nor Connection is provided' {
+            $out = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-SupportBundle-Test-$(Get-Random).json"
+            try {
+                { Export-YarboSupportBundle -Path $out -ErrorAction Stop } | Should -Throw -ErrorId '*SupportBundleNoSource*'
+            } finally {
+                if (Test-Path $out) { Remove-Item -LiteralPath $out -Force }
+            }
+        }
+
+        It 'Creates a valid JSON file when -Connection is provided' {
+            $conn = New-MockYarboConnection -SerialNumber 'BUNDLE-SN' -Broker '192.0.2.1' -Port 1883
+            $conn.CommandLog.Enqueue([PSCustomObject]@{
+                    Timestamp = [datetime]::UtcNow
+                    Command   = 'get_device_msg'
+                    Direction = 'Sent'
+                    Topic     = 'snowbot/BUNDLE-SN/app/get_device_msg'
+                    Broker    = '192.0.2.1:1883'
+                })
+            $conn.TelemetryLog.Enqueue([PSCustomObject]@{
+                    At     = [datetime]::UtcNow
+                    Topic  = 'snowbot/BUNDLE-SN/device/DeviceMSG'
+                    Source = 'DeviceMSG'
+                })
+
+            $out = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-SupportBundle-$(Get-Random).json"
+            try {
+                $result = Export-YarboSupportBundle -Path $out -Connection $conn
+                $result | Should -Not -BeNullOrEmpty
+                $result.FullName | Should -Be (Resolve-Path -LiteralPath $out).Path
+                Test-Path -LiteralPath $out | Should -BeTrue
+                $json = Get-Content -LiteralPath $out -Raw | ConvertFrom-Json
+                $json.ExportDate   | Should -Not -BeNullOrEmpty
+                $json.Module       | Should -Be 'PSYarbo'
+                $json.Source      | Should -Contain 'Connection'
+                $json.ConnectionLog.Broker        | Should -Be '192.0.2.1'
+                $json.ConnectionLog.SerialNumber  | Should -Be 'BUNDLE-SN'
+                $json.ConnectionLog.CommandLog.Count   | Should -BeGreaterThan 0
+                $json.ConnectionLog.TelemetryLog.Count | Should -BeGreaterThan 0
+            } finally {
+                $conn.Dispose()
+                if (Test-Path $out) { Remove-Item -LiteralPath $out -Force }
+            }
+        }
+
+        It 'Creates a valid JSON file when -RecordingPath is provided' {
+            $recDir = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-Rec-$(Get-Random)"
+            $recPath = Join-Path $recDir 'recording.json'
+            $outPath = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-SupportBundle-$(Get-Random).json"
+            try {
+                New-Item -ItemType Directory -Path $recDir -Force | Out-Null
+                $rec = [PSCustomObject]@{
+                    RecordedAt      = [datetime]::UtcNow.ToString('o')
+                    Broker          = '192.0.2.2'
+                    Port            = 1883
+                    DurationSeconds = 10
+                    MessageCount    = 1
+                    Messages        = @(
+                        [PSCustomObject]@{
+                            Index        = 0
+                            Topic        = 'snowbot/SN1/device/DeviceMSG'
+                            PayloadBase64 = [Convert]::ToBase64String([byte[]]@(0x78, 0x9C))  # minimal zlib header
+                        }
+                    )
+                }
+                $rec | ConvertTo-Json -Depth 5 -Compress:$false | Set-Content -LiteralPath $recPath -Encoding UTF8
+
+                $result = Export-YarboSupportBundle -Path $outPath -RecordingPath $recPath
+                $result | Should -Not -BeNullOrEmpty
+                Test-Path -LiteralPath $outPath | Should -BeTrue
+                $json = Get-Content -LiteralPath $outPath -Raw | ConvertFrom-Json
+                $json.Source    | Should -Contain 'Recording'
+                $json.Recording.Broker           | Should -Be '192.0.2.2'
+                $json.Recording.MessageCount     | Should -Be 1
+                $json.Recording.Topics.PSObject.Properties.Name | Should -Contain 'snowbot/SN1/device/DeviceMSG'
+            } finally {
+                if (Test-Path $outPath) { Remove-Item -LiteralPath $outPath -Force }
+                if (Test-Path $recPath) { Remove-Item -LiteralPath $recPath -Force }
+                if (Test-Path $recDir) { Remove-Item -LiteralPath $recDir -Recurse -Force }
+            }
+        }
+
+        It 'Has synopsis and examples in help' {
+            $help = Get-Help Export-YarboSupportBundle
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $help.Synopsis | Should -Not -Be 'Export-YarboSupportBundle'
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Accepts Connection from pipeline' {
+            $conn = New-MockYarboConnection
+            $out = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-SupportBundle-Pipe-$(Get-Random).json"
+            try {
+                $result = $conn | Export-YarboSupportBundle -Path $out
+                $result | Should -Not -BeNullOrEmpty
+                $json = Get-Content -LiteralPath $out -Raw | ConvertFrom-Json
+                $json.Source | Should -Contain 'Connection'
+            } finally {
+                $conn.Dispose()
+                if (Test-Path $out) { Remove-Item -LiteralPath $out -Force }
+            }
+        }
+    }
+}
+
+AfterAll {
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+}

--- a/tests/Unit/ErrorHelper.Tests.ps1
+++ b/tests/Unit/ErrorHelper.Tests.ps1
@@ -1,0 +1,33 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Unit tests for New-YarboError (ErrorHelper).
+#>
+
+BeforeAll {
+    $scriptRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    . (Join-Path $scriptRoot 'Classes' 'YarboExceptions.ps1')
+    . (Join-Path $scriptRoot 'Private' 'ErrorHelper.ps1')
+}
+
+Describe 'New-YarboError' {
+    It 'Returns an ErrorRecord' {
+        $err = New-YarboError -Message 'Test' -ErrorId 'PSYarbo.Test.Id'
+        $err | Should -Not -BeNullOrEmpty
+        $err | Should -BeOfType [System.Management.Automation.ErrorRecord]
+    }
+
+    It 'Sets ErrorId and Message' {
+        $err = New-YarboError -Message 'Timeout' -ErrorId 'PSYarbo.Timeout.GetDeviceMsg'
+        $err.FullyQualifiedErrorId | Should -Be 'PSYarbo.Timeout.GetDeviceMsg'
+        $err.Exception.Message | Should -Be 'Timeout'
+    }
+
+    It 'Accepts Category and TargetObject' {
+        $target = [PSCustomObject]@{ Broker = '192.0.2.1' }
+        $err = New-YarboError -Message 'Failed' -ErrorId 'PSYarbo.Fail' -Category OperationTimeout -TargetObject $target
+        $err.CategoryInfo.Category | Should -Be 'OperationTimeout'
+        $err.TargetObject.Broker | Should -Be '192.0.2.1'
+    }
+}

--- a/tests/Unit/PrivateFunctions.Tests.ps1
+++ b/tests/Unit/PrivateFunctions.Tests.ps1
@@ -62,6 +62,24 @@ Describe 'ConfigManager' {
         $result = Test-YarboConfig -Overrides @{ Broker = '192.168.0.1'; SN = 'TEST123' }
         $result | Should -BeTrue
     }
+
+    It 'Get-YarboConfig resolves Email from env YARBO_EMAIL' {
+        $env:YARBO_EMAIL = 'user@example.com'
+        $cfg = Get-YarboConfig
+        $cfg['Email'] | Should -Be 'user@example.com'
+        $env:YARBO_EMAIL = $script:origEmail
+    }
+
+    It 'Merge-YarboConfig merges with priority explicit > env > file > defaults' {
+        $defaults = @{ Port = 1883; Broker = $null }
+        $file = @{ Broker = 'file.broker'; SN = 'file-sn' }
+        $envLayer = @{ Broker = 'env.broker' }
+        $explicit = @{ Broker = 'param.broker' }
+        $merged = Merge-YarboConfig -Defaults $defaults -File $file -Env $envLayer -Explicit $explicit
+        $merged['Broker'] | Should -Be 'param.broker'
+        $merged['SN'] | Should -Be 'file-sn'
+        $merged['Port'] | Should -Be 1883
+    }
 }
 
 Describe 'CredentialHelper' {

--- a/tests/Unit/PrivateFunctions.Tests.ps1
+++ b/tests/Unit/PrivateFunctions.Tests.ps1
@@ -39,16 +39,16 @@ Describe 'ConfigManager' {
     }
 
     It 'Get-YarboConfig resolves Broker from env var' {
-        $env:YARBO_BROKER = '192.168.0.1'
+        $env:YARBO_BROKER = '192.0.2.1'
         $cfg = Get-YarboConfig
-        $cfg['Broker'] | Should -Be '192.168.0.1'
+        $cfg['Broker'] | Should -Be '192.0.2.1'
         $env:YARBO_BROKER = $null
     }
 
     It 'Get-YarboConfig Overrides take priority over env vars' {
-        $env:YARBO_BROKER = '192.168.0.1'
-        $cfg = Get-YarboConfig -Overrides @{ Broker = '192.168.0.2' }
-        $cfg['Broker'] | Should -Be '192.168.0.2'
+        $env:YARBO_BROKER = '192.0.2.1'
+        $cfg = Get-YarboConfig -Overrides @{ Broker = '192.0.2.2' }
+        $cfg['Broker'] | Should -Be '192.0.2.2'
         $env:YARBO_BROKER = $null
     }
 
@@ -59,7 +59,7 @@ Describe 'ConfigManager' {
     }
 
     It 'Test-YarboConfig returns true when Broker and SN are provided via overrides' {
-        $result = Test-YarboConfig -Overrides @{ Broker = '192.168.0.1'; SN = 'TEST123' }
+        $result = Test-YarboConfig -Overrides @{ Broker = '192.0.2.1'; SN = 'TEST123' }
         $result | Should -BeTrue
     }
 

--- a/tests/Unit/PrivateFunctions.Tests.ps1
+++ b/tests/Unit/PrivateFunctions.Tests.ps1
@@ -39,16 +39,16 @@ Describe 'ConfigManager' {
     }
 
     It 'Get-YarboConfig resolves Broker from env var' {
-        $env:YARBO_BROKER = '10.0.0.1'
+        $env:YARBO_BROKER = '192.168.0.1'
         $cfg = Get-YarboConfig
-        $cfg['Broker'] | Should -Be '10.0.0.1'
+        $cfg['Broker'] | Should -Be '192.168.0.1'
         $env:YARBO_BROKER = $null
     }
 
     It 'Get-YarboConfig Overrides take priority over env vars' {
-        $env:YARBO_BROKER = '10.0.0.1'
-        $cfg = Get-YarboConfig -Overrides @{ Broker = '192.168.1.1' }
-        $cfg['Broker'] | Should -Be '192.168.1.1'
+        $env:YARBO_BROKER = '192.168.0.1'
+        $cfg = Get-YarboConfig -Overrides @{ Broker = '192.168.0.2' }
+        $cfg['Broker'] | Should -Be '192.168.0.2'
         $env:YARBO_BROKER = $null
     }
 
@@ -59,7 +59,7 @@ Describe 'ConfigManager' {
     }
 
     It 'Test-YarboConfig returns true when Broker and SN are provided via overrides' {
-        $result = Test-YarboConfig -Overrides @{ Broker = '192.168.1.1'; SN = 'TEST123' }
+        $result = Test-YarboConfig -Overrides @{ Broker = '192.168.0.1'; SN = 'TEST123' }
         $result | Should -BeTrue
     }
 }

--- a/tests/Unit/PrivateFunctions.Tests.ps1
+++ b/tests/Unit/PrivateFunctions.Tests.ps1
@@ -69,17 +69,6 @@ Describe 'ConfigManager' {
         $cfg['Email'] | Should -Be 'user@example.com'
         $env:YARBO_EMAIL = $script:origEmail
     }
-
-    It 'Merge-YarboConfig merges with priority explicit > env > file > defaults' {
-        $defaults = @{ Port = 1883; Broker = $null }
-        $file = @{ Broker = 'file.broker'; SN = 'file-sn' }
-        $envLayer = @{ Broker = 'env.broker' }
-        $explicit = @{ Broker = 'param.broker' }
-        $merged = Merge-YarboConfig -Defaults $defaults -File $file -Env $envLayer -Explicit $explicit
-        $merged['Broker'] | Should -Be 'param.broker'
-        $merged['SN'] | Should -Be 'file-sn'
-        $merged['Port'] | Should -Be 1883
-    }
 }
 
 Describe 'CredentialHelper' {

--- a/tests/Unit/PublicCmdlets.Tests.ps1
+++ b/tests/Unit/PublicCmdlets.Tests.ps1
@@ -38,6 +38,10 @@ InModuleScope PSYarbo {
             Get-Alias -Name 'Return-YarboToDock' -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
         }
 
+        It 'Has alias Start-YarboRecharge' {
+            Get-Alias -Name 'Start-YarboRecharge' -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+
         It 'Has Medium ConfirmImpact' {
             $cmd = Get-Command Send-YarboReturnToDock
             $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }

--- a/tests/Unit/PublicCmdlets.Tests.ps1
+++ b/tests/Unit/PublicCmdlets.Tests.ps1
@@ -38,10 +38,6 @@ InModuleScope PSYarbo {
             Get-Alias -Name 'Return-YarboToDock' -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
         }
 
-        It 'Has alias Start-YarboRecharge' {
-            Get-Alias -Name 'Start-YarboRecharge' -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
-        }
-
         It 'Has Medium ConfirmImpact' {
             $cmd = Get-Command Send-YarboReturnToDock
             $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }

--- a/tests/Unit/TelemetryParser.Tests.ps1
+++ b/tests/Unit/TelemetryParser.Tests.ps1
@@ -1,0 +1,32 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+BeforeAll {
+    $scriptRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    $fixturesDir = Join-Path $PSScriptRoot '..' 'Fixtures'
+    . (Join-Path $scriptRoot 'Classes' 'YarboTelemetry.ps1')
+    . (Join-Path $scriptRoot 'Private' 'TelemetryParser.ps1')
+}
+Describe 'ConvertFrom-GnggaSentence' {
+    It 'Returns null coordinates for empty string' {
+        $r = ConvertFrom-GnggaSentence -Sentence ''
+        $r.Latitude | Should -BeNullOrEmpty
+        $r.Longitude | Should -BeNullOrEmpty
+        $r.FixQuality | Should -Be 0
+    }
+    It 'Parses valid GNGGA with fix' {
+        $nmea = '$GNGGA,142800.10,5920.05710640,N,01829.82358143,E,4,35,0.5,42.3,M,,,*7B'
+        $r = ConvertFrom-GnggaSentence -Sentence $nmea
+        $r.FixQuality | Should -Be 4
+        $r.Latitude | Should -Not -BeNullOrEmpty
+        $r.Longitude | Should -Not -BeNullOrEmpty
+    }
+}
+Describe 'ConvertTo-YarboTelemetry' {
+    It 'Maps DeviceMSG fixture to YarboTelemetry' {
+        $json = Get-Content (Join-Path $fixturesDir 'DeviceMSG-sample.json') -Raw | ConvertFrom-Json
+        $t = ConvertTo-YarboTelemetry -DeviceMsg $json -SerialNumber 'TEST-SN'
+        $t | Should -Not -BeNullOrEmpty
+        $t.SerialNumber | Should -Be 'TEST-SN'
+        $t.BatteryCapacity | Should -Be 83
+    }
+}

--- a/tests/Unit/TypedCommands.Tests.ps1
+++ b/tests/Unit/TypedCommands.Tests.ps1
@@ -1,0 +1,677 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+using module ../../src/PSYarbo/PSYarbo.psd1
+<#
+.SYNOPSIS
+    Unit tests for the ~37 typed command cmdlets added in PR #59.
+    Note: issue #30 covers Find-YarboDevice endpoint discovery (Rover vs DC),
+    which is a separate feature. This test file covers the typed control cmdlets.
+#>
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+    Import-Module -Name (Join-Path $moduleRoot 'PSYarbo.psd1') -Force -WarningAction SilentlyContinue
+
+    $classFiles = @(
+        'YarboExceptions', 'YarboLightState', 'YarboCommandResult',
+        'YarboTelemetry', 'YarboPlan', 'YarboSchedule', 'YarboRobot',
+        'YarboConnection', 'YarboCloudSession'
+    )
+    foreach ($cf in $classFiles) { . (Join-Path $moduleRoot "Classes/$cf.ps1") }
+}
+
+InModuleScope PSYarbo {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'Helpers' 'MockMqttClient.ps1')
+    }
+
+    # ─── Robot Control ─────────────────────────────────────────────────────────
+
+    Describe 'Stop-YarboEmergency' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Stop-YarboEmergency' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ConfirmImpact High' {
+            $cmd = Get-Command Stop-YarboEmergency
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.ConfirmImpact | Should -Be 'High'
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Stop-YarboEmergency
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Stop-YarboEmergency
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $help.Synopsis | Should -Not -Be 'Stop-YarboEmergency'
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Unlock-YarboEmergency' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Unlock-YarboEmergency' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Unlock-YarboEmergency
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Unlock-YarboEmergency
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Stop-Yarbo' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Stop-Yarbo' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Stop-Yarbo
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Stop-Yarbo
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Restart-YarboContainer' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Restart-YarboContainer' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ConfirmImpact High' {
+            $cmd = Get-Command Restart-YarboContainer
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.ConfirmImpact | Should -Be 'High'
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Restart-YarboContainer
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Stop-YarboShutdown' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Stop-YarboShutdown' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ConfirmImpact High' {
+            $cmd = Get-Command Stop-YarboShutdown
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.ConfirmImpact | Should -Be 'High'
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Stop-YarboShutdown
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Start-YarboRecharge' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Start-YarboRecharge' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Start-YarboRecharge
+            if ($cmd -is [System.Management.Automation.AliasInfo]) { $cmd = Get-Command $cmd.ResolvedCommand.Name }
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Start-YarboRecharge
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    # ─── Lights & Sound ────────────────────────────────────────────────────────
+
+    Describe 'Set-YarboHeadLight' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboHeadLight' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Enabled parameter of type bool' {
+            $cmd = Get-Command Set-YarboHeadLight
+            $cmd.Parameters.ContainsKey('Enabled') | Should -BeTrue
+            $cmd.Parameters['Enabled'].ParameterType | Should -Be ([bool])
+            $mandatoryAttr = $cmd.Parameters['Enabled'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboHeadLight
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Set-YarboRoofLights' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboRoofLights' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Enabled parameter' {
+            $cmd = Get-Command Set-YarboRoofLights
+            $mandatoryAttr = $cmd.Parameters['Enabled'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboRoofLights
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Set-YarboLaser' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboLaser' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Enabled parameter' {
+            $cmd = Get-Command Set-YarboLaser
+            $mandatoryAttr = $cmd.Parameters['Enabled'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboLaser
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Set-YarboSound' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboSound' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Volume parameter of type int' {
+            $cmd = Get-Command Set-YarboSound
+            $cmd.Parameters.ContainsKey('Volume') | Should -BeTrue
+            $cmd.Parameters['Volume'].ParameterType | Should -Be ([int])
+            $mandatoryAttr = $cmd.Parameters['Volume'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Volume has ValidateRange 0-10' {
+            $cmd = Get-Command Set-YarboSound
+            $validateRange = $cmd.Parameters['Volume'].Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
+            $validateRange | Should -Not -BeNullOrEmpty
+            $validateRange.MinRange | Should -Be 0
+            $validateRange.MaxRange | Should -Be 10
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboSound
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Start-YarboSong' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Start-YarboSong' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory SongId parameter of type int' {
+            $cmd = Get-Command Start-YarboSong
+            $cmd.Parameters.ContainsKey('SongId') | Should -BeTrue
+            $cmd.Parameters['SongId'].ParameterType | Should -Be ([int])
+            $mandatoryAttr = $cmd.Parameters['SongId'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Start-YarboSong
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    # ─── Camera & Detection ────────────────────────────────────────────────────
+
+    Describe 'Set-YarboCamera' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboCamera' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Enabled parameter of type bool' {
+            $cmd = Get-Command Set-YarboCamera
+            $cmd.Parameters['Enabled'].ParameterType | Should -Be ([bool])
+            $mandatoryAttr = $cmd.Parameters['Enabled'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboCamera
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Set-YarboPersonDetect' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboPersonDetect' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Enabled parameter' {
+            $cmd = Get-Command Set-YarboPersonDetect
+            $mandatoryAttr = $cmd.Parameters['Enabled'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboPersonDetect
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Set-YarboUSB' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Set-YarboUSB' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Enabled parameter of type bool' {
+            $cmd = Get-Command Set-YarboUSB
+            $cmd.Parameters['Enabled'].ParameterType | Should -Be ([bool])
+            $mandatoryAttr = $cmd.Parameters['Enabled'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Set-YarboUSB
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    # ─── Plans & Scheduling ────────────────────────────────────────────────────
+
+    Describe 'Get-YarboAllPlans' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboAllPlans' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Does not require mandatory parameters' {
+            $cmd = Get-Command Get-YarboAllPlans
+            $mandatoryParams = $cmd.Parameters.Values | Where-Object {
+                $_.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            }
+            $mandatoryParams | Should -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboAllPlans
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Remove-YarboAllPlans' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Remove-YarboAllPlans' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ConfirmImpact High' {
+            $cmd = Get-Command Remove-YarboAllPlans
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.ConfirmImpact | Should -Be 'High'
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Remove-YarboAllPlans
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Remove-YarboAllPlans
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Invoke-YarboPlanAction' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Invoke-YarboPlanAction' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Action parameter of type string' {
+            $cmd = Get-Command Invoke-YarboPlanAction
+            $cmd.Parameters.ContainsKey('Action') | Should -BeTrue
+            $cmd.Parameters['Action'].ParameterType | Should -Be ([string])
+            $mandatoryAttr = $cmd.Parameters['Action'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Invoke-YarboPlanAction
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboSchedules' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboSchedules' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboSchedules
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    # ─── Navigation & Maps ─────────────────────────────────────────────────────
+
+    Describe 'Start-YarboWaypoint' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Start-YarboWaypoint' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has mandatory Index parameter of type int' {
+            $cmd = Get-Command Start-YarboWaypoint
+            $cmd.Parameters.ContainsKey('Index') | Should -BeTrue
+            $cmd.Parameters['Index'].ParameterType | Should -Be ([int])
+            $mandatoryAttr = $cmd.Parameters['Index'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $mandatoryAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Start-YarboWaypoint
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboRechargePoint' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboRechargePoint' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboRechargePoint
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Save-YarboChargingPoint' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Save-YarboChargingPoint' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Save-YarboChargingPoint
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Save-YarboChargingPoint
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboCleanArea' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboCleanArea' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboCleanArea
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboMapBackup' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboMapBackup' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboMapBackup
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Save-YarboMapBackup' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Save-YarboMapBackup' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Save-YarboMapBackup
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Save-YarboMapBackup
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    # ─── WiFi & Connectivity ───────────────────────────────────────────────────
+
+    Describe 'Get-YarboWifiList' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboWifiList' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboWifiList
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboConnectedWifi' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboConnectedWifi' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboConnectedWifi
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Start-YarboHotspot' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Start-YarboHotspot' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has ShouldProcess support' {
+            $cmd = Get-Command Start-YarboHotspot
+            $attr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Start-YarboHotspot
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboHubInfo' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboHubInfo' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboHubInfo
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    # ─── Diagnostics ───────────────────────────────────────────────────────────
+
+    Describe 'Get-YarboBatteryCellTemps' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboBatteryCellTemps' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboBatteryCellTemps
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboMotorTemps' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboMotorTemps' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboMotorTemps
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboBodyCurrent' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboBodyCurrent' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboBodyCurrent
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboHeadCurrent' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboHeadCurrent' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboHeadCurrent
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboSpeed' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboSpeed' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboSpeed
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboOdometer' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboOdometer' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboOdometer
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboProductCode' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboProductCode' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboProductCode
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Describe 'Get-YarboNoChargePeriod' {
+        It 'Is exported from the module' {
+            Get-Command -Name 'Get-YarboNoChargePeriod' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has synopsis and example in help' {
+            $help = Get-Help Get-YarboNoChargePeriod
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $examples = if ($help.PSObject.Properties.Match('examples').Count -gt 0 -and $help.examples) { $help.examples.example } else { @() }
+            $examples.Count | Should -BeGreaterThan 0
+        }
+    }
+}
+
+AfterAll {
+    if (Get-Module -Name PSYarbo) { Remove-Module -Name PSYarbo -Force }
+}

--- a/tests/Unit/YarboSchedule.Tests.ps1
+++ b/tests/Unit/YarboSchedule.Tests.ps1
@@ -1,0 +1,54 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Unit tests for YarboSchedule class (GetDays, ToString, properties).
+    Loads only the Schedule class to avoid full module.
+#>
+
+BeforeAll {
+    $scriptRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    . (Join-Path $scriptRoot 'Classes' 'YarboSchedule.ps1')
+}
+
+Describe 'YarboSchedule' {
+    It 'Can be instantiated' {
+        $s = [YarboSchedule]::new()
+        $s | Should -Not -BeNull
+    }
+
+    It 'GetDays returns empty when WeekDay is 0' {
+        $s = [YarboSchedule]::new()
+        $s.WeekDay = 0
+        $days = $s.GetDays()
+        $days.Length | Should -Be 0
+    }
+
+    It 'GetDays returns single day when WeekDay is 1 (Sunday)' {
+        $s = [YarboSchedule]::new()
+        $s.WeekDay = 1
+        $days = $s.GetDays()
+        $days.Length | Should -Be 1
+        $days[0].ToString() | Should -Be 'Sunday'
+    }
+
+    It 'GetDays returns all days when WeekDay is 127' {
+        $s = [YarboSchedule]::new()
+        $s.WeekDay = 127
+        $days = $s.GetDays()
+        $days.Length | Should -Be 7
+    }
+
+    It 'ToString includes name and time range' {
+        $s = [YarboSchedule]::new()
+        $s.Name = 'Morning'
+        $s.StartTime = '08:00'
+        $s.EndTime = '10:00'
+        $s.WeekDay = 127
+        $s.Enabled = $true
+        $str = $s.ToString()
+        $str | Should -BeLike '*Morning*'
+        $str | Should -BeLike '*08:00*10:00*'
+        $str | Should -BeLike '*Daily*'
+    }
+}

--- a/tests/Unit/ZlibCodec.Tests.ps1
+++ b/tests/Unit/ZlibCodec.Tests.ps1
@@ -1,0 +1,45 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+.SYNOPSIS
+    Unit tests for Zlib payload compression (Private/ZlibCodec.ps1).
+#>
+
+BeforeAll {
+    $scriptRoot = Join-Path $PSScriptRoot '..' '..' 'src' 'PSYarbo'
+    . (Join-Path $scriptRoot 'Private' 'ZlibCodec.ps1')
+}
+
+Describe 'ConvertTo-ZlibPayload' {
+    It 'Compresses a simple hashtable to non-empty bytes' {
+        $payload = @{ foo = 'bar' }
+        $bytes = ConvertTo-ZlibPayload -Payload $payload
+        $bytes | Should -Not -BeNullOrEmpty
+        $bytes -is [byte[]] | Should -BeTrue
+        $bytes.Length | Should -BeGreaterThan 0
+    }
+
+    It 'Round-trips with ConvertFrom-ZlibPayload' {
+        $payload = @{ cmd = 'get_controller'; id = 1 }
+        $bytes = ConvertTo-ZlibPayload -Payload $payload
+        $decoded = ConvertFrom-ZlibPayload -Data $bytes
+        $decoded | Should -Not -BeNullOrEmpty
+        $decoded.cmd | Should -Be 'get_controller'
+        $decoded.id | Should -Be 1
+    }
+}
+
+Describe 'ConvertFrom-ZlibPayload' {
+    It 'Returns null for empty byte array' {
+        $result = ConvertFrom-ZlibPayload -Data @()
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'Decompresses valid zlib bytes from round-trip' {
+        $original = @{ topic = 'read_schedules'; state = 0 }
+        $bytes = ConvertTo-ZlibPayload -Payload $original
+        $decoded = ConvertFrom-ZlibPayload -Data $bytes
+        $decoded.topic | Should -Be 'read_schedules'
+        $decoded.state | Should -Be 0
+    }
+}

--- a/tools/Analyze-MqttRecordingGaps.ps1
+++ b/tools/Analyze-MqttRecordingGaps.ps1
@@ -19,7 +19,7 @@ param(
 $ErrorActionPreference = 'Stop'
 if (-not (Test-Path -LiteralPath $RecordingPath)) { Write-Error "Not found: $RecordingPath"; exit 1 }
 
-function Expand-ZlibBytes {
+function Expand-ZlibByte {
     param([byte[]]$Data)
     if (-not $Data -or $Data.Length -eq 0) { return $null }
     try {
@@ -32,7 +32,7 @@ function Expand-ZlibBytes {
     } catch { return $null }
 }
 
-function Get-AllKeys {
+function Get-AllKey {
     param([PSCustomObject]$Obj, [string]$Prefix = '')
     $keys = [System.Collections.Generic.List[string]]::new()
     if (-not $Obj) { return @() }
@@ -41,7 +41,7 @@ function Get-AllKeys {
         $path = if ($Prefix) { "$Prefix.$name" } else { $name }
         $keys.Add($path)
         $val = $p.Value
-        if ($val -is [PSCustomObject]) { foreach ($sub in (Get-AllKeys -Obj $val -Prefix $path)) { $keys.Add($sub) } }
+        if ($val -is [PSCustomObject]) { foreach ($sub in (Get-AllKey -Obj $val -Prefix $path)) { $keys.Add($sub) } }
         elseif ($val -is [System.Collections.IDictionary]) {
             foreach ($k in $val.Keys) { $keys.Add("$path.$k") }
         }
@@ -88,7 +88,7 @@ foreach ($m in $messages) {
     if ($m.PayloadBase64) {
         try {
             $bytes = [Convert]::FromBase64String($m.PayloadBase64)
-            $decoded = Expand-ZlibBytes -Data $bytes
+            $decoded = Expand-ZlibByte -Data $bytes
             if (-not $decoded) {
                 $str = [System.Text.Encoding]::UTF8.GetString($bytes)
                 if ($str.TrimStart().StartsWith('{')) { $decoded = $str | ConvertFrom-Json }
@@ -96,7 +96,7 @@ foreach ($m in $messages) {
         } catch { $null = $_ }
     }
     if ($decoded) {
-        $keys = Get-AllKeys -Obj $decoded
+        $keys = Get-AllKey -Obj $decoded
         foreach ($k in $keys) { $null = $allSeenKeys.Add($k) }
         foreach ($k in $keys) { $byTopic[$suffix].Add($k) | Out-Null }
     }

--- a/tools/Analyze-MqttRecordingGaps.ps1
+++ b/tools/Analyze-MqttRecordingGaps.ps1
@@ -1,0 +1,124 @@
+<#
+.SYNOPSIS
+    Analyze an MQTT recording and list payload keys not exposed by any cmdlet.
+
+.DESCRIPTION
+    Reads a recording JSON (from Record-YarboMqtt.ps1 or Invoke-YarboMqttSniff -RecordPath)
+    and reports which payload keys are NOT surfaced as first-class cmdlet output.
+    For meaningful results, use a recording of real MQTT from your robot (not synthetic/fixture data).
+    This script works without loading the full module (e.g. in CI).
+
+.PARAMETER RecordingPath
+    Path to the recording JSON file.
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$RecordingPath
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path -LiteralPath $RecordingPath)) { Write-Error "Not found: $RecordingPath"; exit 1 }
+
+function Decompress-ZlibBytes {
+    param([byte[]]$Data)
+    if (-not $Data -or $Data.Length -eq 0) { return $null }
+    try {
+        $ms = [System.IO.MemoryStream]::new($Data)
+        $zlib = [System.IO.Compression.ZLibStream]::new($ms, [System.IO.Compression.CompressionMode]::Decompress)
+        $reader = [System.IO.StreamReader]::new($zlib, [System.Text.Encoding]::UTF8)
+        $json = $reader.ReadToEnd()
+        $reader.Close(); $zlib.Dispose(); $ms.Dispose()
+        return $json | ConvertFrom-Json
+    } catch { return $null }
+}
+
+function Get-AllKeys {
+    param([PSCustomObject]$Obj, [string]$Prefix = '')
+    $keys = [System.Collections.Generic.List[string]]::new()
+    if (-not $Obj) { return @() }
+    foreach ($p in $Obj.PSObject.Properties) {
+        $name = $p.Name
+        $path = if ($Prefix) { "$Prefix.$name" } else { $name }
+        $keys.Add($path)
+        $val = $p.Value
+        if ($val -is [PSCustomObject]) { foreach ($sub in (Get-AllKeys -Obj $val -Prefix $path)) { $keys.Add($sub) } }
+        elseif ($val -is [System.Collections.IDictionary]) {
+            foreach ($k in $val.Keys) { $keys.Add("$path.$k") }
+        }
+    }
+    return @($keys)
+}
+
+# Keys we expose as first-class properties on YarboRobot / YarboTelemetry / plan_feedback / recharge_feedback / heart_beat
+$ExposedKeys = @(
+    'BatteryMSG.capacity','BatteryMSG.status','BatteryMSG.temp_err','BatteryMSG.timestamp','BatteryMSG.current','BatteryMSG.voltage',
+    'BodyMsg.recharge_state',
+    'CombinedOdom.x','CombinedOdom.y','CombinedOdom.phi',
+    'HeadMsg.head_type','HeadMsg.head_led_brightness','HeadSerialMsg.head_sn',
+    'RTKMSG.heading','RTKMSG.heading_status','RTKMSG.status','RTKMSG.heading_dop',
+    'RTKMSG.gga_atn_dis','RTKMSG.heading_atn_dis','RTKMSG.heading_multi','RTKMSG.heading_obs','RTKMSG.pre4_timestamp','RTKMSG.rtk_version','RTKMSG.sat_num','RTKMSG.timestamp',
+    'RunningStatusMSG.chute_angle','RunningStatusMSG.rain_sensor_data','RunningStatusMSG.chute_steering_engine_info','RunningStatusMSG.chute_steering_run_status',
+    'RunningStatusMSG.head_gyro_pitch','RunningStatusMSG.head_gyro_roll','RunningStatusMSG.push_pod_status','RunningStatusMSG.push_rod_place',
+    'RunningStatusMSG.snow_pipe_run_status','RunningStatusMSG.snow_roller_motor','RunningStatusMSG.elec_navigation_front_right_sensor','RunningStatusMSG.elec_navigation_rear_right_sensor',
+    'StateMSG.working_state','StateMSG.charging_status','StateMSG.error_code','StateMSG.machine_controller','StateMSG.car_controller',
+    'StateMSG.on_going_planning','StateMSG.planning_paused','StateMSG.on_going_recharging',
+    'StateMSG.adjustangle_status','StateMSG.auto_draw_waiting_state','StateMSG.en_state_led','StateMSG.en_warn_led',
+    'StateMSG.on_going_to_start_point','StateMSG.on_mul_points','StateMSG.robot_follow_state','StateMSG.schedule_cancel','StateMSG.vision_auto_draw_state',
+    'combined_odom_confidence','led','route_priority','ultrasonic_msg.lf_dis','ultrasonic_msg.mt_dis','ultrasonic_msg.rf_dis',
+    'wireless_recharge.state','wireless_recharge.output_voltage','wireless_recharge.output_current','wireless_recharge.error_code',
+    'rtk_base_data.rover.gngga','rtk_base_data.rover.heading','rtk_base_data.base.gngga','timestamp',
+    'rtcm_age','rtcm_info','LedInfoMSG','EletricMSG.brushless_motor_current','EletricMSG.ntc_temperature','EletricMSG.push_pod_current',
+    'base_status','bds','bs','green_grass_update_switch','ipcamera_ota_switch','ms','s','sbs','tms','system_info','DebugMsg',
+    'topic','state','msg','data',
+    'working_state','planId','areaCovered','duration','dock_id'
+)
+$ExposedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+foreach ($k in $ExposedKeys) { $null = $ExposedSet.Add($k) }
+
+$raw = Get-Content -LiteralPath $RecordingPath -Raw -Encoding UTF8 | ConvertFrom-Json
+$messages = @($raw.Messages)
+$allSeenKeys = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+$byTopic = @{}
+
+foreach ($m in $messages) {
+    $topic = $m.Topic
+    $suffix = if ($topic -match 'snowbot/[^/]+/(.+)$') { $Matches[1] } else { $topic }
+    if (-not $byTopic[$suffix]) { $byTopic[$suffix] = [System.Collections.Generic.List[string]]::new() }
+    $decoded = $null
+    if ($m.PayloadBase64) {
+        try {
+            $bytes = [Convert]::FromBase64String($m.PayloadBase64)
+            $decoded = Decompress-ZlibBytes -Data $bytes
+            if (-not $decoded) {
+                $str = [System.Text.Encoding]::UTF8.GetString($bytes)
+                if ($str.TrimStart().StartsWith('{')) { $decoded = $str | ConvertFrom-Json }
+            }
+        } catch { $null = $_ }
+    }
+    if ($decoded) {
+        $keys = Get-AllKeys -Obj $decoded
+        foreach ($k in $keys) { $null = $allSeenKeys.Add($k) }
+        foreach ($k in $keys) { $byTopic[$suffix].Add($k) | Out-Null }
+    }
+}
+
+$notExposed = [System.Collections.Generic.List[string]]::new()
+foreach ($k in $allSeenKeys) {
+    $covered = $false
+    foreach ($exp in $ExposedSet) {
+        if ($k -eq $exp -or $k.StartsWith($exp + '.') -or $exp.StartsWith($k + '.')) { $covered = $true; break }
+    }
+    if (-not $covered) { $notExposed.Add($k) | Out-Null }
+}
+
+Write-Host "=== MQTT recording: $RecordingPath ==="
+Write-Host "Messages: $($raw.MessageCount) | Topics: $(($byTopic.Keys | Sort-Object) -join ', ')"
+Write-Host ""
+Write-Host "--- Payload keys NOT exposed as first-class output by any cmdlet ---"
+if ($notExposed.Count -eq 0) {
+    Write-Host "  (none – all seen keys are mapped to Get-YarboStatus / Get-YarboTelemetry / Watch-YarboTelemetry / connection properties)"
+} else {
+    $notExposed | Sort-Object | ForEach-Object { Write-Host "  $_" }
+}
+Write-Host ""
+Write-Host "--- Note: Full DeviceMSG is always available as .RawMessage on the object from Get-YarboStatus / Get-YarboRobot ---"

--- a/tools/Analyze-MqttRecordingGaps.ps1
+++ b/tools/Analyze-MqttRecordingGaps.ps1
@@ -19,7 +19,7 @@ param(
 $ErrorActionPreference = 'Stop'
 if (-not (Test-Path -LiteralPath $RecordingPath)) { Write-Error "Not found: $RecordingPath"; exit 1 }
 
-function Decompress-ZlibBytes {
+function Expand-ZlibBytes {
     param([byte[]]$Data)
     if (-not $Data -or $Data.Length -eq 0) { return $null }
     try {
@@ -51,26 +51,26 @@ function Get-AllKeys {
 
 # Keys we expose as first-class properties on YarboRobot / YarboTelemetry / plan_feedback / recharge_feedback / heart_beat
 $ExposedKeys = @(
-    'BatteryMSG.capacity','BatteryMSG.status','BatteryMSG.temp_err','BatteryMSG.timestamp','BatteryMSG.current','BatteryMSG.voltage',
+    'BatteryMSG.capacity', 'BatteryMSG.status', 'BatteryMSG.temp_err', 'BatteryMSG.timestamp', 'BatteryMSG.current', 'BatteryMSG.voltage',
     'BodyMsg.recharge_state',
-    'CombinedOdom.x','CombinedOdom.y','CombinedOdom.phi',
-    'HeadMsg.head_type','HeadMsg.head_led_brightness','HeadSerialMsg.head_sn',
-    'RTKMSG.heading','RTKMSG.heading_status','RTKMSG.status','RTKMSG.heading_dop',
-    'RTKMSG.gga_atn_dis','RTKMSG.heading_atn_dis','RTKMSG.heading_multi','RTKMSG.heading_obs','RTKMSG.pre4_timestamp','RTKMSG.rtk_version','RTKMSG.sat_num','RTKMSG.timestamp',
-    'RunningStatusMSG.chute_angle','RunningStatusMSG.rain_sensor_data','RunningStatusMSG.chute_steering_engine_info','RunningStatusMSG.chute_steering_run_status',
-    'RunningStatusMSG.head_gyro_pitch','RunningStatusMSG.head_gyro_roll','RunningStatusMSG.push_pod_status','RunningStatusMSG.push_rod_place',
-    'RunningStatusMSG.snow_pipe_run_status','RunningStatusMSG.snow_roller_motor','RunningStatusMSG.elec_navigation_front_right_sensor','RunningStatusMSG.elec_navigation_rear_right_sensor',
-    'StateMSG.working_state','StateMSG.charging_status','StateMSG.error_code','StateMSG.machine_controller','StateMSG.car_controller',
-    'StateMSG.on_going_planning','StateMSG.planning_paused','StateMSG.on_going_recharging',
-    'StateMSG.adjustangle_status','StateMSG.auto_draw_waiting_state','StateMSG.en_state_led','StateMSG.en_warn_led',
-    'StateMSG.on_going_to_start_point','StateMSG.on_mul_points','StateMSG.robot_follow_state','StateMSG.schedule_cancel','StateMSG.vision_auto_draw_state',
-    'combined_odom_confidence','led','route_priority','ultrasonic_msg.lf_dis','ultrasonic_msg.mt_dis','ultrasonic_msg.rf_dis',
-    'wireless_recharge.state','wireless_recharge.output_voltage','wireless_recharge.output_current','wireless_recharge.error_code',
-    'rtk_base_data.rover.gngga','rtk_base_data.rover.heading','rtk_base_data.base.gngga','timestamp',
-    'rtcm_age','rtcm_info','LedInfoMSG','EletricMSG.brushless_motor_current','EletricMSG.ntc_temperature','EletricMSG.push_pod_current',
-    'base_status','bds','bs','green_grass_update_switch','ipcamera_ota_switch','ms','s','sbs','tms','system_info','DebugMsg',
-    'topic','state','msg','data',
-    'working_state','planId','areaCovered','duration','dock_id'
+    'CombinedOdom.x', 'CombinedOdom.y', 'CombinedOdom.phi',
+    'HeadMsg.head_type', 'HeadMsg.head_led_brightness', 'HeadSerialMsg.head_sn',
+    'RTKMSG.heading', 'RTKMSG.heading_status', 'RTKMSG.status', 'RTKMSG.heading_dop',
+    'RTKMSG.gga_atn_dis', 'RTKMSG.heading_atn_dis', 'RTKMSG.heading_multi', 'RTKMSG.heading_obs', 'RTKMSG.pre4_timestamp', 'RTKMSG.rtk_version', 'RTKMSG.sat_num', 'RTKMSG.timestamp',
+    'RunningStatusMSG.chute_angle', 'RunningStatusMSG.rain_sensor_data', 'RunningStatusMSG.chute_steering_engine_info', 'RunningStatusMSG.chute_steering_run_status',
+    'RunningStatusMSG.head_gyro_pitch', 'RunningStatusMSG.head_gyro_roll', 'RunningStatusMSG.push_pod_status', 'RunningStatusMSG.push_rod_place',
+    'RunningStatusMSG.snow_pipe_run_status', 'RunningStatusMSG.snow_roller_motor', 'RunningStatusMSG.elec_navigation_front_right_sensor', 'RunningStatusMSG.elec_navigation_rear_right_sensor',
+    'StateMSG.working_state', 'StateMSG.charging_status', 'StateMSG.error_code', 'StateMSG.machine_controller', 'StateMSG.car_controller',
+    'StateMSG.on_going_planning', 'StateMSG.planning_paused', 'StateMSG.on_going_recharging',
+    'StateMSG.adjustangle_status', 'StateMSG.auto_draw_waiting_state', 'StateMSG.en_state_led', 'StateMSG.en_warn_led',
+    'StateMSG.on_going_to_start_point', 'StateMSG.on_mul_points', 'StateMSG.robot_follow_state', 'StateMSG.schedule_cancel', 'StateMSG.vision_auto_draw_state',
+    'combined_odom_confidence', 'led', 'route_priority', 'ultrasonic_msg.lf_dis', 'ultrasonic_msg.mt_dis', 'ultrasonic_msg.rf_dis',
+    'wireless_recharge.state', 'wireless_recharge.output_voltage', 'wireless_recharge.output_current', 'wireless_recharge.error_code',
+    'rtk_base_data.rover.gngga', 'rtk_base_data.rover.heading', 'rtk_base_data.base.gngga', 'timestamp',
+    'rtcm_age', 'rtcm_info', 'LedInfoMSG', 'EletricMSG.brushless_motor_current', 'EletricMSG.ntc_temperature', 'EletricMSG.push_pod_current',
+    'base_status', 'bds', 'bs', 'green_grass_update_switch', 'ipcamera_ota_switch', 'ms', 's', 'sbs', 'tms', 'system_info', 'DebugMsg',
+    'topic', 'state', 'msg', 'data',
+    'working_state', 'planId', 'areaCovered', 'duration', 'dock_id'
 )
 $ExposedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
 foreach ($k in $ExposedKeys) { $null = $ExposedSet.Add($k) }
@@ -88,7 +88,7 @@ foreach ($m in $messages) {
     if ($m.PayloadBase64) {
         try {
             $bytes = [Convert]::FromBase64String($m.PayloadBase64)
-            $decoded = Decompress-ZlibBytes -Data $bytes
+            $decoded = Expand-ZlibBytes -Data $bytes
             if (-not $decoded) {
                 $str = [System.Text.Encoding]::UTF8.GetString($bytes)
                 if ($str.TrimStart().StartsWith('{')) { $decoded = $str | ConvertFrom-Json }

--- a/tools/MqttSniff.ps1
+++ b/tools/MqttSniff.ps1
@@ -12,7 +12,7 @@
 .PARAMETER DurationSeconds
     How long to capture. Default 15.
 .EXAMPLE
-    .\tools\MqttSniff.ps1 -Broker 192.168.0.1 -DurationSeconds 20
+    .\tools\MqttSniff.ps1 -Broker <rover-ip> -DurationSeconds 20
 #>
 [CmdletBinding()]
 param(

--- a/tools/MqttSniff.ps1
+++ b/tools/MqttSniff.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+    Sniff all MQTT messages from a broker for troubleshooting (topic + payload size).
+.DESCRIPTION
+    Connects to the given broker, subscribes to # (all topics), and logs every
+    message received for the specified duration. Use to verify that the broker
+    sends Yarbo traffic and to see actual topic names (snowbot/ vs yarbo/ etc.).
+.PARAMETER Broker
+    Broker IP or hostname (use Find-YarboDevice or Find-Yarbo to discover).
+.PARAMETER Port
+    MQTT port. Default 1883.
+.PARAMETER DurationSeconds
+    How long to capture. Default 15.
+.EXAMPLE
+    .\tools\MqttSniff.ps1 -Broker 192.168.0.1 -DurationSeconds 20
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Broker,
+    [int]$Port = 1883,
+    [int]$DurationSeconds = 15
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptRoot = Split-Path $PSScriptRoot -Parent
+Import-Module (Join-Path $scriptRoot 'src' 'PSYarbo') -Force -WarningAction SilentlyContinue
+
+$logFile = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-MqttSniff-$(Get-Date -Format 'yyyyMMddHHmmss').log"
+Write-Host "LogPath: $logFile"
+
+Write-Host "=== PowerShell adapter sniffer (adapter debug log shows if handler is invoked) ==="
+Invoke-YarboMqttSniff -Broker $Broker -Port $Port -DurationSeconds $DurationSeconds -SelfTest -LogPath $logFile
+$fi = Get-Item $logFile -ErrorAction SilentlyContinue; Write-Host "Log file size: $(if ($fi) { $fi.Length } else { 0 }) bytes"

--- a/tools/MqttSniff.ps1
+++ b/tools/MqttSniff.ps1
@@ -1,25 +1,28 @@
 <#
 .SYNOPSIS
-    Sniff all MQTT messages from a broker for troubleshooting (topic + payload size).
+    Sniff MQTT messages from a broker (topic + size; optional full recording).
 .DESCRIPTION
-    Connects to the given broker, subscribes to # (all topics), and logs every
-    message received for the specified duration. Use to verify that the broker
-    sends Yarbo traffic and to see actual topic names (snowbot/ vs yarbo/ etc.).
+    Connects to the broker, subscribes to snowbot/# (Yarbo traffic), and logs
+    each message. Use -RecordPath to save full payloads for Get-YarboMqttRecordingReport.
 .PARAMETER Broker
     Broker IP or hostname (use Find-YarboDevice or Find-Yarbo to discover).
 .PARAMETER Port
     MQTT port. Default 1883.
 .PARAMETER DurationSeconds
-    How long to capture. Default 15.
+    How long to capture. Default 15. Use 60 for a one-minute recording.
+.PARAMETER RecordPath
+    If set, save a JSON recording of all messages for coverage report.
 .EXAMPLE
-    .\tools\MqttSniff.ps1 -Broker <rover-ip> -DurationSeconds 20
+    .\tools\MqttSniff.ps1 -Broker <rover-ip> -DurationSeconds 60 -RecordPath ./recording.json
+    Get-YarboMqttRecordingReport -RecordingPath ./recording.json
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
     [string]$Broker,
     [int]$Port = 1883,
-    [int]$DurationSeconds = 15
+    [int]$DurationSeconds = 15,
+    [string]$RecordPath
 )
 
 $ErrorActionPreference = 'Stop'
@@ -29,6 +32,7 @@ Import-Module (Join-Path $scriptRoot 'src' 'PSYarbo') -Force -WarningAction Sile
 $logFile = Join-Path ([System.IO.Path]::GetTempPath()) "PSYarbo-MqttSniff-$(Get-Date -Format 'yyyyMMddHHmmss').log"
 Write-Host "LogPath: $logFile"
 
-Write-Host "=== PowerShell adapter sniffer (adapter debug log shows if handler is invoked) ==="
-Invoke-YarboMqttSniff -Broker $Broker -Port $Port -DurationSeconds $DurationSeconds -SelfTest -LogPath $logFile
+$params = @{ Broker = $Broker; Port = $Port; DurationSeconds = $DurationSeconds; SelfTest = $true; LogPath = $logFile }
+if ($RecordPath) { $params['RecordPath'] = $RecordPath }
+Invoke-YarboMqttSniff @params
 $fi = Get-Item $logFile -ErrorAction SilentlyContinue; Write-Host "Log file size: $(if ($fi) { $fi.Length } else { 0 }) bytes"

--- a/tools/Record-YarboMqtt.ps1
+++ b/tools/Record-YarboMqtt.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Record real MQTT traffic from your Yarbo robot and analyze coverage.
+
+.DESCRIPTION
+    Records live MQTT from the robot's broker (real data, not synthetic/fixture).
+    Connects to the broker, subscribes to snowbot/#, and records all messages for
+    the specified duration (default 60 seconds). Saves full payloads to a JSON file
+    and runs Get-YarboMqttRecordingReport to show which topics were seen and which
+    cmdlets expose that data. Run this on a machine on the same LAN as the robot;
+    ensure build/Install-Dependencies.ps1 has been run so MQTTnet is available.
+
+.PARAMETER Broker
+    Broker IP or hostname. Optional if -DiscoverBroker is used.
+
+.PARAMETER DiscoverBroker
+    Discover the robot with Find-Yarbo and use its broker for recording (recommended).
+
+.PARAMETER Port
+    MQTT port. Default 1883.
+
+.PARAMETER DurationSeconds
+    How long to record. Default 60 (one minute).
+
+.PARAMETER OutDir
+    Directory for recording and report files. Default: current directory.
+
+.PARAMETER SkipReport
+    If set, only record; do not run the coverage report.
+
+.EXAMPLE
+    .\tools\Record-YarboMqtt.ps1 -DiscoverBroker
+    Record 60s from the first robot found on the network (real MQTT).
+.EXAMPLE
+    .\tools\Record-YarboMqtt.ps1 -Broker 192.168.1.42 -DurationSeconds 60
+    Record 60s from a known broker (real MQTT).
+#>
+[CmdletBinding(DefaultParameterSetName = 'Broker')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Broker')]
+    [string]$Broker,
+    [Parameter(Mandatory, ParameterSetName = 'Discover')]
+    [switch]$DiscoverBroker,
+    [int]$Port = 1883,
+    [int]$DurationSeconds = 60,
+    [string]$OutDir = '.',
+    [switch]$SkipReport
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptRoot = Split-Path $PSScriptRoot -Parent
+Import-Module (Join-Path $scriptRoot 'src' 'PSYarbo') -Force -WarningAction SilentlyContinue
+
+if ($PSCmdlet.ParameterSetName -eq 'Discover') {
+    Write-Host "Discovering robot on the network..."
+    $found = Find-Yarbo -TimeoutSeconds 15 -ErrorAction Stop
+    if (-not $found -or $found.Count -eq 0) { throw "No Yarbo found. Ensure the robot is on and on the same LAN." }
+    $Broker = $found[0].Broker
+    Write-Host "Using broker: $Broker (SN: $($found[0].SerialNumber))"
+}
+
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$recordPath = Join-Path $OutDir "PSYarbo-MqttRecording-$stamp.json"
+$reportPath = Join-Path $OutDir "PSYarbo-MqttReport-$stamp.txt"
+
+Write-Host "Recording real MQTT for ${DurationSeconds}s from ${Broker}:${Port} -> $recordPath"
+$summary = Invoke-YarboMqttSniff -Broker $Broker -Port $Port -DurationSeconds $DurationSeconds -RecordPath $recordPath
+
+if (-not $SkipReport -and (Test-Path -LiteralPath $recordPath)) {
+    Write-Host ""
+    Get-YarboMqttRecordingReport -RecordingPath $recordPath -OutPath $reportPath
+    Write-Host ""
+    Write-Host "Report file: $reportPath"
+}

--- a/tools/Record-YarboMqtt.ps1
+++ b/tools/Record-YarboMqtt.ps1
@@ -64,7 +64,7 @@ $recordPath = Join-Path $OutDir "PSYarbo-MqttRecording-$stamp.json"
 $reportPath = Join-Path $OutDir "PSYarbo-MqttReport-$stamp.txt"
 
 Write-Host "Recording real MQTT for ${DurationSeconds}s from ${Broker}:${Port} -> $recordPath"
-$summary = Invoke-YarboMqttSniff -Broker $Broker -Port $Port -DurationSeconds $DurationSeconds -RecordPath $recordPath
+Invoke-YarboMqttSniff -Broker $Broker -Port $Port -DurationSeconds $DurationSeconds -RecordPath $recordPath
 
 if (-not $SkipReport -and (Test-Path -LiteralPath $recordPath)) {
     Write-Host ""


### PR DESCRIPTION
## Summary
This PR consolidates discovery improvements, display consistency, full MQTT-to-object mapping, and integration tests for review.

## Discovery & connection
- **Find-YarboDevice**: Discover endpoints, label Rover vs DC (MAC), recommend one per device, output in failover order (recommended first).
- **Find-Yarbo**: Deduplicate by SerialNumber (one robot per device).
- **ArpHelper.ps1**: Get-MacForIp, Test-LocallyAdministeredMac, Invoke-ArpPrime.
- **NetworkHelper.ps1**: Get-PSYarboLocalSubnets (use machine's networks when no `-Subnet`).
- **YarboEndpoint** class; warning when scanning >512 hosts.

## Display consistency
- Script properties **Battery**, **State** (and where relevant HeadingDisplay, Time, Areas, SelfOrder, Days, EnabledDisplay, WeatherDisplay, RecommendedDisplay) on YarboRobot, YarboTelemetry, YarboPlan, YarboSchedule, YarboEndpoint so `Format-Table`, `Format-List`, and `Select-Object *` show the same concepts.

## Full MQTT → PowerShell objects
- **YarboRobot** & **YarboTelemetry**: All DeviceMSG fields (BatteryMSG, BodyMsg, StateMSG, RTKMSG, RunningStatusMSG, wireless_recharge, ultrasonic_msg, led, route_priority, timestamps); `RawMessage` / `GnggaRaw` where applicable.
- **YarboGlobalParams** class (MowSpeed, CuttingHeight, RainDelay, ObstacleSensitivity, Timestamp, RawData); `Get-YarboGlobalParams` returns `[YarboGlobalParams]`.
- **TelemetryParser**: ConvertTo-YarboRobot / ConvertTo-YarboTelemetry map every reversed field.

## Tests & tooling
- **Integration tests**: Find-Yarbo → Connect-Yarbo → Get-Yarbo* (Status, Robot, Battery, Firmware, GlobalParams, Map, Plan, Schedule, Telemetry, Log) → Disconnect (`tests/Integration/FindConnectGetYarbo.Integration.Tests.ps1`).
- Class count updated to 11 (YarboGlobalParams added).

## Checklist
- [ ] Review discovery (Find-YarboDevice, Find-Yarbo) and Rover/DC/failover behavior
- [ ] Review display script properties and format/type files
- [ ] Review new YarboRobot/YarboTelemetry/YarboGlobalParams properties and parser
- [ ] Run integration tests on a machine that can reach a Yarbo (`Invoke-Pester ./tests/Integration/FindConnectGetYarbo.Integration.Tests.ps1 -Tag Integration`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes core MQTT module loading/connection and network discovery paths, plus expands cloud credential handling; regressions could break connect/discovery or message routing. Adds multiple new robot-control cmdlets (some destructive) but generally gated behind `SupportsShouldProcess`/`ConfirmImpact`.
> 
> **Overview**
> **Discovery and MQTT reliability are expanded.** `Find-Yarbo` now auto-scans local interface subnets (or `-Subnet`), verifies brokers via a new C# `YarboMqttListener`, and deduplicates results by serial number; a new `Find-YarboDevice` command discovers multiple endpoints per robot, resolves MACs, labels *Rover vs DC*, and outputs a recommended failover order.
> 
> **Status/telemetry data and formatting are broadened.** `YarboRobot`/`YarboTelemetry` gain many additional DeviceMSG-backed fields plus `RawMessage`, parsing is refactored via a shared `Set-YarboCommonFields`, and type/format data is updated to use consistent display script properties (e.g. `Battery`, `State`, display-friendly heading/time). `Get-YarboGlobalParams` now returns a typed `YarboGlobalParams` (with `RawData`), and `Set-YarboGlobalParams` accepts either a hashtable or that object.
> 
> **New tooling, commands, and pipeline updates.** Adds env-driven MQTT debug logging (`PSYARBO_DEBUG`, `PSYARBO_DEBUG_RAW`), MQTT sniff/record support (`Invoke-YarboMqttSniff`), and exports additional utility/control cmdlets (camera, maps, firmware update, mower/head settings, etc.). CI is updated to install dependencies and split Pester into unit/integration/root runs, and docs/README are expanded with a new “Commands and Properties” guide and improved examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13b1673e14d8654931bb5cf145c6217732ce0c29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->